### PR TITLE
Add HTML export feature for interactive charts

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokercraft-local-web",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokercraft-local-web",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "dependencies": {
         "@types/react-plotly.js": "^2.6.4",
         "jszip": "^3.10.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokercraft-local-web",
   "private": true,
-  "version": "3.0.1",
+  "version": "3.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -63,6 +63,29 @@
   background: #333;
 }
 
+.header .export-button {
+  color: #888;
+  font-size: 0.875rem;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid #444;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: inherit;
+}
+
+.header .export-button:hover:not(:disabled) {
+  color: #fff;
+  border-color: #666;
+  background: #333;
+}
+
+.header .export-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 /* File Uploader */
 .file-uploader {
   margin-bottom: 2rem;

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -4,9 +4,10 @@
 
 interface HeaderProps {
   wasmVersion: string
+  onExport?: () => void
 }
 
-export function Header({ wasmVersion }: HeaderProps) {
+export function Header({ wasmVersion, onExport }: HeaderProps) {
   const appVersion = __APP_VERSION__
   const gitHash = __GIT_HASH__
 
@@ -17,6 +18,14 @@ export function Header({ wasmVersion }: HeaderProps) {
         <span className="subtitle">Poker Analytics Dashboard</span>
       </div>
       <div className="header-links">
+        <button
+          className="export-button"
+          onClick={onExport}
+          disabled={!onExport}
+          title={onExport ? 'Export all charts as HTML' : 'Load data to enable export'}
+        >
+          Export HTML
+        </button>
         <a
           href="https://github.com/McDic/pokercraft-local"
           target="_blank"

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -5,5 +5,5 @@
 export { Header } from './Header'
 export { FileUploader } from './FileUploader'
 export { ChartTabs, type ChartTab } from './ChartTabs'
-export { TournamentCharts } from './TournamentCharts'
-export { HandHistoryCharts } from './HandHistoryCharts'
+export { TournamentCharts, type TournamentChartsRef } from './TournamentCharts'
+export { HandHistoryCharts, type HandHistoryChartsRef } from './HandHistoryCharts'

--- a/web/src/export/htmlExport.ts
+++ b/web/src/export/htmlExport.ts
@@ -101,6 +101,8 @@ export function generateExportHTML(
 ): string {
   const timestamp = new Date().toLocaleString()
   const appVersion = __APP_VERSION__
+  const gitHash = __GIT_HASH__
+  const hashSuffix = gitHash && gitHash !== 'unknown' ? ` (${escapeHtml(gitHash)})` : ''
 
   const hasTournament = tournamentCharts.length > 0
   const hasHandHistory = handHistoryCharts.length > 0
@@ -117,7 +119,7 @@ export function generateExportHTML(
 <body>
   <div class="export-header">
     <h1>Pokercraft Local</h1>
-    <div class="meta">Exported on ${escapeHtml(timestamp)} &middot; v${escapeHtml(appVersion)}</div>
+    <div class="meta">Exported on ${escapeHtml(timestamp)} &middot; v${escapeHtml(appVersion)}${hashSuffix}</div>
   </div>
   ${
     hasTournament

--- a/web/src/export/htmlExport.ts
+++ b/web/src/export/htmlExport.ts
@@ -1,0 +1,154 @@
+/**
+ * HTML export utility for generating standalone Plotly chart files
+ */
+
+import type { Data, Layout } from 'plotly.js-dist-min'
+
+export interface ExportChart {
+  name: string
+  traces: Data[]
+  layout: Partial<Layout>
+}
+
+const PLOTLY_CDN = 'https://cdn.plot.ly/plotly-3.3.1.min.js'
+
+const THEME_CSS = `
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #111;
+    color: #ddd;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    padding: 2rem;
+  }
+  .export-header {
+    text-align: center;
+    margin-bottom: 2rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid #333;
+  }
+  .export-header h1 { font-size: 1.75rem; color: #fff; margin-bottom: 0.25rem; }
+  .export-header .meta { color: #666; font-size: 0.8rem; }
+  .section-title {
+    font-size: 1.25rem;
+    color: #aaa;
+    margin: 2rem 0 1rem 0;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid #282828;
+  }
+  .chart-container {
+    background: #fff;
+    border-radius: 12px;
+    padding: 1rem;
+    margin-bottom: 1.5rem;
+    overflow: hidden;
+  }
+`
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+function buildChartDivs(charts: ExportChart[], prefix: string): string {
+  return charts
+    .map(
+      (_, i) => `<div class="chart-container"><div id="${prefix}-${i}" style="width:100%;"></div></div>`
+    )
+    .join('\n      ')
+}
+
+/** Override axis colors for light background readability */
+function patchAxesForLightTheme(layout: Partial<Layout>): Record<string, unknown> {
+  const src = layout as Record<string, unknown>
+  const patched: Record<string, unknown> = { ...src }
+  const axisOverrides = { gridcolor: '#ddd', zerolinecolor: '#bbb', linecolor: '#ccc' }
+
+  for (const key of Object.keys(src)) {
+    if (/^[xy]axis\d*$/.test(key) && typeof src[key] === 'object' && src[key] !== null) {
+      patched[key] = { ...(src[key] as object), ...axisOverrides }
+    }
+  }
+  return patched
+}
+
+function buildPlotCalls(charts: ExportChart[], prefix: string): string {
+  return charts
+    .map((chart, i) => {
+      const divId = `${prefix}-${i}`
+      const layout: Record<string, unknown> = {
+        ...patchAxesForLightTheme(chart.layout),
+        autosize: true,
+        paper_bgcolor: '#fff',
+        plot_bgcolor: '#fff',
+        font: { ...((chart.layout as Record<string, unknown>).font as object), color: '#333' },
+      }
+      return `Plotly.newPlot(
+        ${JSON.stringify(divId)},
+        ${JSON.stringify(chart.traces)},
+        ${JSON.stringify(layout)},
+        {responsive: true}
+      );`
+    })
+    .join('\n      ')
+}
+
+export function generateExportHTML(
+  tournamentCharts: ExportChart[],
+  handHistoryCharts: ExportChart[]
+): string {
+  const timestamp = new Date().toLocaleString()
+  const appVersion = __APP_VERSION__
+
+  const hasTournament = tournamentCharts.length > 0
+  const hasHandHistory = handHistoryCharts.length > 0
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pokercraft Local - Exported Charts</title>
+  <script src="${escapeHtml(PLOTLY_CDN)}"><\/script>
+  <style>${THEME_CSS}</style>
+</head>
+<body>
+  <div class="export-header">
+    <h1>Pokercraft Local</h1>
+    <div class="meta">Exported on ${escapeHtml(timestamp)} &middot; v${escapeHtml(appVersion)}</div>
+  </div>
+  ${
+    hasTournament
+      ? `<h2 class="section-title">Tournament Summary</h2>
+      ${buildChartDivs(tournamentCharts, 'tournament')}`
+      : ''
+  }
+  ${
+    hasHandHistory
+      ? `<h2 class="section-title">Hand History</h2>
+      ${buildChartDivs(handHistoryCharts, 'hand')}`
+      : ''
+  }
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      ${hasTournament ? buildPlotCalls(tournamentCharts, 'tournament') : ''}
+      ${hasHandHistory ? buildPlotCalls(handHistoryCharts, 'hand') : ''}
+    });
+  <\/script>
+</body>
+</html>`
+}
+
+export function downloadHTML(html: string, filename: string): void {
+  const blob = new Blob([html], { type: 'text/html;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## Summary
- Added an "Export HTML" button to the header toolbar that generates a standalone HTML file containing all current Plotly charts from both Tournament Summary and Hand History tabs
- Exported file loads Plotly from CDN and renders interactive charts with white chart backgrounds on a dark page theme for readability
- Displays app version and git commit hash in the exported file header

## Implementation
- Chart components (`TournamentCharts`, `HandHistoryCharts`) expose chart data via `forwardRef` + `useImperativeHandle`
- New `web/src/export/htmlExport.ts` utility generates the HTML and triggers browser download
- Export button is disabled when no data is loaded
- Bumped web version to 3.1.0

## Test plan
- [ ] Load tournament + hand history files
- [ ] Click the "Export HTML" button in the header
- [ ] Verify the downloaded HTML file opens in a browser with all interactive charts
- [ ] Verify charts have white backgrounds and are readable
- [ ] Verify version and git hash appear in the exported file header
- [ ] Verify export button is disabled when no data is loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)