### PR TITLE
Fix hand history parser for new GGNetwork format

### DIFF
--- a/web/src/parser/handHistoryParser.test.ts
+++ b/web/src/parser/handHistoryParser.test.ts
@@ -189,4 +189,92 @@ Seat 7: Hero (button) folded before Flop
     const results = parseHandHistory('')
     expect(results).toHaveLength(0)
   })
+
+  it('should parse new format with ante in level info', () => {
+    const newFormatHand = `
+Poker Hand #TM5890117982: Tournament #280241902, Daily Special $3 Hold'em No Limit - Level10(250/500(60)) - 2026/04/30 22:25:46
+Table '53' 8-max Seat #5 is the button
+Seat 1: 5ad653e7 (20,480 in chips)
+Seat 2: ba03baf9 (5,205 in chips)
+Seat 3: Hero (19,050 in chips)
+5ad653e7: posts the ante 60
+ba03baf9: posts the ante 60
+Hero: posts the ante 60
+5ad653e7: posts small blind 250
+ba03baf9: posts big blind 500
+*** HOLE CARDS ***
+Dealt to 5ad653e7
+Dealt to ba03baf9
+Dealt to Hero [8c Tc]
+Hero: raises 500 to 1,000
+5ad653e7: folds
+ba03baf9: folds
+Uncalled bet (500) returned to Hero
+*** SHOWDOWN ***
+Hero collected 1,180 from pot
+*** SUMMARY ***
+Total pot 1,180 | Rake 0 | Jackpot 0 | Bingo 0 | Fortune 0 | Tax 0
+Seat 1: 5ad653e7 (small blind) folded before Flop
+Seat 2: ba03baf9 (big blind) folded before Flop
+Seat 3: Hero won (1,180)
+`.trim()
+
+    const results = parseHandHistory(newFormatHand)
+    expect(results).toHaveLength(1)
+
+    const hand = results[0]
+    expect(hand.id).toBe('TM5890117982')
+    expect(hand.tournamentId).toBe(280241902)
+    expect(hand.level).toBe(10)
+    expect(hand.sb).toBe(250)
+    expect(hand.bb).toBe(500)
+    expect(hand.maxSeats).toBe(8)
+    expect(hand.buttonSeat).toBe(5)
+    expect(hand.datetime.getFullYear()).toBe(2026)
+    expect(hand.datetime.getMonth()).toBe(3) // April (0-indexed)
+
+    // Antes parsed from action lines
+    const antes = hand.actionsPreflop.filter(a => a.action === 'ante')
+    expect(antes).toHaveLength(3)
+    expect(antes.every(a => a.amount === 60)).toBe(true)
+
+    expect(hand.wons.get('Hero')).toBe(1180)
+    expect(hand.uncalledReturned).toEqual(['Hero', 500])
+  })
+
+  it('should parse new format with large ante (Flipout)', () => {
+    const flipoutHand = `
+Poker Hand #TM5760010691: Tournament #274416465, Daily $100,000 #ThanksGG Flipout Hold'em No Limit - Level1(500/1,000(2,000,000,000)) - 2026/04/04 17:45:02
+Table '1' 8-max Seat #3 is the button
+Seat 1: abc12345 (10,000 in chips)
+Seat 2: Hero (10,000 in chips)
+abc12345: posts the ante 2,000,000,000
+Hero: posts the ante 2,000,000,000
+abc12345: posts small blind 500
+Hero: posts big blind 1,000
+*** HOLE CARDS ***
+Dealt to abc12345
+Dealt to Hero [As Kd]
+abc12345: folds
+Uncalled bet (500) returned to Hero
+*** SHOWDOWN ***
+Hero collected 4,000,001,000 from pot
+*** SUMMARY ***
+Total pot 4,000,001,000 | Rake 0 | Jackpot 0 | Bingo 0 | Fortune 0 | Tax 0
+Seat 1: abc12345 (small blind) folded before Flop
+Seat 2: Hero (big blind) won (4,000,001,000)
+`.trim()
+
+    const results = parseHandHistory(flipoutHand)
+    expect(results).toHaveLength(1)
+
+    const hand = results[0]
+    expect(hand.sb).toBe(500)
+    expect(hand.bb).toBe(1000)
+    expect(hand.level).toBe(1)
+
+    const antes = hand.actionsPreflop.filter(a => a.action === 'ante')
+    expect(antes).toHaveLength(2)
+    expect(antes[0].amount).toBe(2000000000)
+  })
 })

--- a/web/src/parser/handHistoryParser.ts
+++ b/web/src/parser/handHistoryParser.ts
@@ -6,7 +6,7 @@
 import type { HandHistory, BetAction, HandStage, CardString } from '../types'
 
 // Regex patterns for hand history files
-const LINE1_INTRO = /^Poker Hand #(TM|BR|SG)(\d+): Tournament #(\d+), (.+) - Level(\d+)\(([\d,]+)\/([\d,]+)\) - (\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2})$/
+const LINE1_INTRO = /^Poker Hand #(TM|BR|SG)(\d+): Tournament #(\d+), (.+) - Level(\d+)\(([\d,]+)\/([\d,]+)(?:\([\d,]+\))?\) - (\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2})$/
 const LINE2_TABLE_NUM = /^Table '(\d+)' (\d+)-max Seat #(\d+) is the button$/
 const LINE3_SEAT_INFO = /^Seat (\d+): ([0-9a-f]+|Hero) \(([\d,]+) in chips\)$/
 const LINE4_POSTS_DEAD_MONEY = /^([0-9a-f]+|Hero): posts (?:the )?(ante|big blind|small blind) ([\d,]+)$/


### PR DESCRIPTION
## Summary
- GGNetwork changed their hand history format around March 2026 to embed ante in the level info: `Level10(250/500(60))` instead of old `Level16(600/1,200)`
- Updated `LINE1_INTRO` regex to accept the optional `(<ante>)` suffix after BB value
- Added tests for new format including Flipout tournaments with large antes

## Test plan
- [x] Existing tests pass (old format backward-compatible)
- [x] New tests for `Level10(250/500(60))` format
- [x] New test for Flipout `Level1(500/1,000(2,000,000,000))` format
- [x] Manually verified parsing of `damavaco_handhistory_202604.zip` data in local dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)