### PR TITLE
Bump web version to 3.1.2

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokercraft-local-web",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokercraft-local-web",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "dependencies": {
         "@types/react-plotly.js": "^2.6.4",
         "jszip": "^3.10.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokercraft-local-web",
   "private": true,
-  "version": "3.1.1",
+  "version": "3.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bump web package version from 3.1.1 to 3.1.2
- Patch release covering hand history parser fix (#12) and web CI addition (#13)
- Rust workspace version unchanged (no Rust code changes)

## Test plan
- [x] Only project-level version entries updated in package-lock.json (no dependency versions touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)