### PR TITLE
Fix luck score not recalculating on incremental hand-history updates

### DIFF
--- a/web/src/components/HandHistoryCharts.tsx
+++ b/web/src/components/HandHistoryCharts.tsx
@@ -33,7 +33,6 @@ export interface HandHistoryChartsRef {
 
 // Global cache for equity results (persists across re-renders)
 const equityCache = new Map<string, AllInHandData>()
-let cachedLuckScore = 0
 
 export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryChartsProps>(
   function HandHistoryCharts({ handHistories }, ref) {
@@ -90,7 +89,7 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
       try {
         const [
           { getChipHistoriesData, getHandUsageHeatmapsData },
-          { collectAllInDataAsync, createAllInEquityChart },
+          { collectAllInDataAsync, createAllInEquityChart, calculateLuckScore },
         ] = await Promise.all([
           import('../visualization'),
           import('../visualization/handHistory/allInEquityAsync'),
@@ -140,7 +139,7 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
           }))
 
           // Calculate equity only for uncached hands
-          const { data: newAllInData, luckScore: newLuckScore } = await collectAllInDataAsync(
+          const { data: newAllInData } = await collectAllInDataAsync(
             uncachedHands,
             (current, total) => {
               if (!isStale()) {
@@ -161,12 +160,6 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
           for (const data of newAllInData) {
             equityCache.set(data.handId, data)
           }
-
-          // Recalculate luck score with all cached data
-          // (simplified: we store the latest, but ideally recalculate from all)
-          if (newAllInData.length > 0) {
-            cachedLuckScore = newLuckScore
-          }
         }
 
         // Get all cached results for current hand histories
@@ -178,7 +171,11 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
           }
         }
 
-        const allInEquity = createAllInEquityChart(allCachedData, cachedLuckScore)
+        // Recalculate luck score from all loaded hands (not just the latest batch)
+        const luckScore = await calculateLuckScore(allCachedData)
+        if (isStale()) return
+
+        const allInEquity = createAllInEquityChart(allCachedData, luckScore)
 
         setState(prev => ({
           ...prev,

--- a/web/src/visualization/handHistory/allInEquityAsync.ts
+++ b/web/src/visualization/handHistory/allInEquityAsync.ts
@@ -126,12 +126,12 @@ function filterEligibleHands(handHistories: HandHistory[]): EligibleHand[] {
 export async function collectAllInDataAsync(
   handHistories: HandHistory[],
   onProgress?: (current: number, total: number) => void
-): Promise<{ data: AllInHandData[]; luckScore: number }> {
+): Promise<{ data: AllInHandData[] }> {
   // Filter eligible hands on main thread (fast)
   const eligible = filterEligibleHands(handHistories)
 
   if (eligible.length === 0) {
-    return { data: [], luckScore: 0 }
+    return { data: [] }
   }
 
   // Determine number of workers (use available cores, max 8)
@@ -214,55 +214,39 @@ export async function collectAllInDataAsync(
   const results = await Promise.all(workerPromises)
   const allData = results.flat()
 
-
-  // Calculate combined luck score
-  const wasmModule = await import('../../wasm/pokercraft_wasm')
-  await wasmModule.default()  // Initialize WASM
-  const luckCalc = new wasmModule.LuckCalculator()
-  for (const data of allData) {
-    try {
-      luckCalc.addResult(data.equity, data.actualResult)
-    } catch {
-      // Skip invalid
-    }
-  }
-  let luckScore = 0
-  try {
-    luckScore = luckCalc.luckScore()
-  } catch {
-    // Failed
-  }
-  luckCalc.free()
-
-  return { data: allData, luckScore }
+  return { data: allData }
 }
 
 /**
- * Recalculate the luck score from a full set of all-in data.
+ * Calculate the luck score from a full set of all-in data.
  *
- * Used on incremental updates so the displayed luck score reflects every
+ * Recomputes from the entire data set so incremental updates reflect every
  * loaded hand, not just the most recently added batch.
+ *
+ * Returns the luck score, or `null` if the WASM calculation failed. `null` is
+ * distinct from a valid neutral score of 0 — callers must treat it as
+ * "calculation failed", not as neutral luck.
  */
-export async function calculateLuckScore(allInData: AllInHandData[]): Promise<number> {
+export async function calculateLuckScore(allInData: AllInHandData[]): Promise<number | null> {
   if (allInData.length === 0) return 0
   const wasmModule = await import('../../wasm/pokercraft_wasm')
-  await wasmModule.default()
+  await wasmModule.default()  // Initialize WASM
   const luckCalc = new wasmModule.LuckCalculator()
-  for (const data of allInData) {
-    try {
-      luckCalc.addResult(data.equity, data.actualResult)
-    } catch {
-      // Skip invalid
-    }
-  }
-  let luckScore = 0
   try {
-    luckScore = luckCalc.luckScore()
-  } catch {
-    // Failed
+    for (const data of allInData) {
+      try {
+        luckCalc.addResult(data.equity, data.actualResult)
+      } catch {
+        // Skip individual invalid results
+      }
+    }
+    return luckCalc.luckScore()
+  } catch (error) {
+    console.warn('Luck score calculation failed:', error)
+    return null
+  } finally {
+    luckCalc.free()
   }
-  luckCalc.free()
-  return luckScore
 }
 
 /**
@@ -270,7 +254,7 @@ export async function calculateLuckScore(allInData: AllInHandData[]): Promise<nu
  */
 export function createAllInEquityChart(
   allInData: AllInHandData[],
-  luckScore: number
+  luckScore: number | null
 ): AllInEquityData {
   if (allInData.length === 0) {
     return {
@@ -408,7 +392,10 @@ export function createAllInEquityChart(
     } as Data,
   ]
 
-  const luckPercentile = 100 * (1 - (1 / (1 + Math.exp(-luckScore * 1.7))))
+  // null score means the WASM calculation failed (distinct from a neutral 0)
+  const luckText = luckScore === null
+    ? 'Luck Score calculation failed'
+    : `Luck Score: ${luckScore.toFixed(2)} (Top ${(100 * (1 - (1 / (1 + Math.exp(-luckScore * 1.7))))).toFixed(1)}%)`
 
   const layout: Partial<Layout> = {
     title: { text: 'All-in Equity Analysis' },
@@ -460,7 +447,7 @@ export function createAllInEquityChart(
     },
     annotations: [
       {
-        text: `${allInData.length} all-ins | Luck Score: ${luckScore.toFixed(2)} (Top ${luckPercentile.toFixed(1)}%)`,
+        text: `${allInData.length} all-ins | ${luckText}`,
         xref: 'paper',
         yref: 'paper',
         x: 0.5,

--- a/web/src/visualization/handHistory/allInEquityAsync.ts
+++ b/web/src/visualization/handHistory/allInEquityAsync.ts
@@ -238,6 +238,34 @@ export async function collectAllInDataAsync(
 }
 
 /**
+ * Recalculate the luck score from a full set of all-in data.
+ *
+ * Used on incremental updates so the displayed luck score reflects every
+ * loaded hand, not just the most recently added batch.
+ */
+export async function calculateLuckScore(allInData: AllInHandData[]): Promise<number> {
+  if (allInData.length === 0) return 0
+  const wasmModule = await import('../../wasm/pokercraft_wasm')
+  await wasmModule.default()
+  const luckCalc = new wasmModule.LuckCalculator()
+  for (const data of allInData) {
+    try {
+      luckCalc.addResult(data.equity, data.actualResult)
+    } catch {
+      // Skip invalid
+    }
+  }
+  let luckScore = 0
+  try {
+    luckScore = luckCalc.luckScore()
+  } catch {
+    // Failed
+  }
+  luckCalc.free()
+  return luckScore
+}
+
+/**
  * Create the chart from pre-computed all-in data
  */
 export function createAllInEquityChart(

--- a/web/src/visualization/handHistory/allInEquityAsync.ts
+++ b/web/src/visualization/handHistory/allInEquityAsync.ts
@@ -223,12 +223,15 @@ export async function collectAllInDataAsync(
  * Recomputes from the entire data set so incremental updates reflect every
  * loaded hand, not just the most recently added batch.
  *
- * Returns the luck score, or `null` if the WASM calculation failed. `null` is
- * distinct from a valid neutral score of 0 — callers must treat it as
- * "calculation failed", not as neutral luck.
+ * Returns a numeric score, or a sentinel string for the unavailable cases:
+ * `'no-data'` when there are no all-in hands and `'failed'` when the WASM
+ * calculation errored. Both are distinct from a valid neutral score of 0 —
+ * callers must not treat them as neutral luck.
  */
-export async function calculateLuckScore(allInData: AllInHandData[]): Promise<number | null> {
-  if (allInData.length === 0) return 0
+export type LuckScore = number | 'no-data' | 'failed'
+
+export async function calculateLuckScore(allInData: AllInHandData[]): Promise<LuckScore> {
+  if (allInData.length === 0) return 'no-data'
   const wasmModule = await import('../../wasm/pokercraft_wasm')
   await wasmModule.default()  // Initialize WASM
   const luckCalc = new wasmModule.LuckCalculator()
@@ -243,7 +246,7 @@ export async function calculateLuckScore(allInData: AllInHandData[]): Promise<nu
     return luckCalc.luckScore()
   } catch (error) {
     console.warn('Luck score calculation failed:', error)
-    return null
+    return 'failed'
   } finally {
     luckCalc.free()
   }
@@ -254,7 +257,7 @@ export async function calculateLuckScore(allInData: AllInHandData[]): Promise<nu
  */
 export function createAllInEquityChart(
   allInData: AllInHandData[],
-  luckScore: number | null
+  luckScore: LuckScore
 ): AllInEquityData {
   if (allInData.length === 0) {
     return {
@@ -392,10 +395,13 @@ export function createAllInEquityChart(
     } as Data,
   ]
 
-  // null score means the WASM calculation failed (distinct from a neutral 0)
-  const luckText = luckScore === null
-    ? 'Luck Score calculation failed'
-    : `Luck Score: ${luckScore.toFixed(2)} (Top ${(100 * (1 - (1 / (1 + Math.exp(-luckScore * 1.7))))).toFixed(1)}%)`
+  // Sentinel scores are unavailable cases, distinct from a neutral 0
+  const luckText =
+    luckScore === 'no-data'
+      ? 'No all-in data'
+      : luckScore === 'failed'
+        ? 'Luck Score calculation failed'
+        : `Luck Score: ${luckScore.toFixed(2)} (Top ${(100 * (1 - (1 / (1 + Math.exp(-luckScore * 1.7))))).toFixed(1)}%)`
 
   const layout: Partial<Layout> = {
     title: { text: 'All-in Equity Analysis' },


### PR DESCRIPTION
## Problem

When hand histories are loaded incrementally, the All-in Equity luck score was computed only from the **most recently added batch** of hands, while the histogram used **all** cached hands. This caused the displayed luck score to mismatch the underlying data. The score also went stale when every hand was already cached (the recompute block was skipped entirely).

The old code even acknowledged this in a comment:
> `// (simplified: we store the latest, but ideally recalculate from all)`

This re-applies the fix from the closed/never-merged #7, adapted to current `master`.

## Fix

- Add `calculateLuckScore(allInData)` to `allInEquityAsync.ts` — builds a fresh `LuckCalculator` over **all** passed hands and returns the score.
- In `HandHistoryCharts.tsx`: remove the `cachedLuckScore` global and the "store only the latest batch" logic; recompute `luckScore` from the full `allCachedData` set right before chart creation, with a staleness guard.

## Verification

- `tsc --noEmit` — clean
- `npm test` — 44/44 pass
- `npm run lint` — no new errors (pre-existing errors unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)