### PR TITLE
Cache Rust build in deploy-web workflow

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -36,6 +36,14 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+          shared-key: "wasm-build"
 
       - name: Install wasm-pack
         run: cargo install wasm-pack


### PR DESCRIPTION
## Summary
- Add `Swatinem/rust-cache@v2` to the `Deploy Web to GitHub Pages` workflow to cache `~/.cargo/registry`, `~/.cargo/git`, `target/`, and `~/.cargo/bin/` (which includes `wasm-pack`) between runs.
- Set `wasm32-unknown-unknown` as a toolchain target so it's part of the cache key.

On cache hits this should drop the WASM compile + `cargo install wasm-pack` time from minutes to seconds. Cache lives under GitHub's 10 GB per-repo quota (free, oldest-evicted-first), so no billing risk.

## Test plan
- [ ] Workflow run succeeds on this branch (first run = cache miss, populates cache).
- [ ] Re-run / subsequent push that doesn't change `Cargo.lock` shows a cache hit and noticeably shorter WASM build step.
- [ ] Deployed site at GitHub Pages still works after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)