### PR TITLE
Use commit SHA + datetime as version display

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -32,7 +32,6 @@ function exportTimestamp(): string {
 
 function App() {
   const [activeTab, setActiveTab] = useState<ChartTab>('tournament')
-  const [wasmVersion, setWasmVersion] = useState('')
   const [pendingExport, setPendingExport] = useState<
     { charts: ExportChart[]; isTournament: boolean } | null
   >(null)
@@ -50,16 +49,6 @@ function App() {
     parseFiles,
     runAnalysis,
   } = useAnalysisWorker()
-
-  // Load WASM version on mount
-  useEffect(() => {
-    import('./wasm/pokercraft_wasm').then(async (wasm) => {
-      await wasm.default()
-      setWasmVersion(wasm.version())
-    }).catch(() => {
-      // WASM load failed
-    })
-  }, [])
 
   // Auto-run analysis when new tournament data is added
   // (Hand history analysis is handled independently by HandHistoryCharts)
@@ -113,7 +102,6 @@ function App() {
   return (
     <div className="app">
       <Header
-        wasmVersion={wasmVersion}
         onExport={tournaments.length > 0 || handHistories.length > 0 ? handleExport : undefined}
       />
 

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -2,14 +2,14 @@
  * Application header component
  */
 
+import { getVersionInfo } from '../utils/version'
+
 interface HeaderProps {
-  wasmVersion: string
   onExport?: () => void
 }
 
-export function Header({ wasmVersion, onExport }: HeaderProps) {
-  const appVersion = __APP_VERSION__
-  const gitHash = __GIT_HASH__
+export function Header({ onExport }: HeaderProps) {
+  const version = getVersionInfo()
 
   return (
     <header className="header">
@@ -35,9 +35,17 @@ export function Header({ wasmVersion, onExport }: HeaderProps) {
           GitHub
         </a>
         <span className="version">
-          v{appVersion}
-          {gitHash && gitHash !== 'unknown' && ` (${gitHash})`}
-          {wasmVersion && ` | WASM v${wasmVersion}`}
+          {version.url ? (
+            <a
+              href={version.url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {version.text}
+            </a>
+          ) : (
+            version.text
+          )}
         </span>
       </div>
     </header>

--- a/web/src/export/htmlExport.ts
+++ b/web/src/export/htmlExport.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Data, Layout } from 'plotly.js-dist-min'
+import { getVersionInfo } from '../utils/version'
 
 export interface ExportChart {
   name: string
@@ -100,9 +101,10 @@ export function generateExportHTML(
   handHistoryCharts: ExportChart[]
 ): string {
   const timestamp = new Date().toLocaleString()
-  const appVersion = __APP_VERSION__
-  const gitHash = __GIT_HASH__
-  const hashSuffix = gitHash && gitHash !== 'unknown' ? ` (${escapeHtml(gitHash)})` : ''
+  const version = getVersionInfo()
+  const versionHtml = version.url
+    ? `<a href="${escapeHtml(version.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(version.text)}</a>`
+    : escapeHtml(version.text)
 
   const hasTournament = tournamentCharts.length > 0
   const hasHandHistory = handHistoryCharts.length > 0
@@ -119,7 +121,7 @@ export function generateExportHTML(
 <body>
   <div class="export-header">
     <h1>Pokercraft Local</h1>
-    <div class="meta">Exported on ${escapeHtml(timestamp)} &middot; v${escapeHtml(appVersion)}${hashSuffix}</div>
+    <div class="meta">Exported on ${escapeHtml(timestamp)} &middot; ${versionHtml}</div>
   </div>
   ${
     hasTournament

--- a/web/src/utils/version.ts
+++ b/web/src/utils/version.ts
@@ -1,0 +1,21 @@
+const REPO_URL = 'https://github.com/McDic/pokercraft-local'
+
+export interface VersionInfo {
+  text: string
+  url: string | null
+}
+
+export function getVersionInfo(): VersionInfo {
+  const hash = __GIT_HASH__
+  const ts = __GIT_TIMESTAMP__
+  if (!hash || hash === 'unknown' || !ts) {
+    return { text: 'dev build', url: null }
+  }
+  const d = new Date(ts * 1000)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  const dt = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+  return {
+    text: `${hash} (${dt})`,
+    url: `${REPO_URL}/commit/${hash}`,
+  }
+}

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,4 +1,4 @@
 /// <reference types="vite/client" />
 
-declare const __APP_VERSION__: string
 declare const __GIT_HASH__: string
+declare const __GIT_TIMESTAMP__: number

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,12 +11,21 @@ function getGitHash(): string {
   }
 }
 
+// Get git commit timestamp (Unix seconds) at build time
+function getGitTimestamp(): number {
+  try {
+    return parseInt(execSync('git log -1 --format=%ct HEAD').toString().trim(), 10)
+  } catch {
+    return 0
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   define: {
-    __APP_VERSION__: JSON.stringify(process.env.npm_package_version || '0.0.0'),
     __GIT_HASH__: JSON.stringify(getGitHash()),
+    __GIT_TIMESTAMP__: getGitTimestamp(),
   },
   // Base URL for custom domain (pokercraft.mcdic.net)
   // Use '/' for custom domains, '/<repo-name>/' for github.io URLs


### PR DESCRIPTION
## Summary
- Replace `v3.1.2 (b016605) | WASM v3.1.1` in the header with `b016605 (2026-05-28 HH:MM:SS)`, linked to `…/commit/<sha>` on GitHub. Datetime renders in the user's system timezone.
- Fall back to `dev build` when SHA isn't available (e.g., local dev without git).
- Exported HTML footer follows the same format via a shared `getVersionInfo()` helper, so header and export can't drift.
- Drop unused `__APP_VERSION__` define and the main-thread WASM-version-load effect in `App.tsx` (each worker initializes its own WASM independently — no functional change).

## Test plan
- [x] `npm run build` — green
- [x] `npm test` — 44/44 pass
- [x] Local dev (`npm run dev`) shows `dev build` in header
- [ ] Deployed build shows `<sha> (YYYY-MM-DD HH:MM:SS)` and the SHA links to the right commit
- [ ] Exported HTML footer matches the header format

🤖 Generated with [Claude Code](https://claude.com/claude-code)