### PR TITLE
Fix stale bankroll chart after the first upload

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,11 +26,63 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "jsdom": "^29.1.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^8.0.16",
         "vitest": "^4.1.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -295,6 +347,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@choojs/findup": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
@@ -306,6 +371,146 @@
       },
       "bin": {
         "findup": "bin/findup.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -486,6 +691,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1887,6 +2110,16 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-search-bounds": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
@@ -2272,6 +2505,20 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csscolorparser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
@@ -2447,6 +2694,20 @@
       "license": "BSD-3-Clause",
       "peer": true
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2463,6 +2724,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2576,6 +2844,19 @@
       "peer": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -3572,6 +3853,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -3765,6 +4059,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-string-blank": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
@@ -3807,6 +4108,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -4393,6 +4745,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/minimatch": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
@@ -4680,6 +5039,19 @@
       "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -5128,6 +5500,16 @@
         "regl-scatter2d": "^3.2.3"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -5259,6 +5641,19 @@
       "peer": true,
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -5545,6 +5940,13 @@
         "svg-path-bounds": "^1.0.1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -5612,6 +6014,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
+      "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.8"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
+      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-float32": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/to-float32/-/to-float32-1.1.0.tgz",
@@ -5642,6 +6064,32 @@
         "topo2geo": "bin/topo2geo",
         "topomerge": "bin/topomerge",
         "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5733,6 +6181,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -5972,6 +6430,19 @@
         "pbf": "^3.2.1"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/weak-map": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
@@ -5987,6 +6458,41 @@
       "peer": true,
       "dependencies": {
         "get-canvas-context": "^1.0.1"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -6045,6 +6551,23 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -30,6 +30,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^29.1.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^8.0.16",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,7 +36,6 @@ function App() {
   const [pendingExport, setPendingExport] = useState<
     { charts: ExportChart[]; isTournament: boolean } | null
   >(null)
-  const prevTournamentCountRef = useRef(0)
   const tournamentChartsRef = useRef<TournamentChartsRef>(null)
   const handHistoryChartsRef = useRef<HandHistoryChartsRef>(null)
 
@@ -51,16 +50,15 @@ function App() {
     runAnalysis,
   } = useAnalysisWorker()
 
-  // Auto-run analysis when new tournament data is added
+  // Auto-run analysis whenever the tournament set actually changes. `tournaments`
+  // keeps its identity when a parse adds nothing new, so this fires exactly once
+  // per real data change.
   // (Hand history analysis is handled independently by HandHistoryCharts)
   useEffect(() => {
-    const hasTournamentChanges = tournaments.length !== prevTournamentCountRef.current
-
-    if (hasTournamentChanges && !isLoading && tournaments.length > 0) {
-      prevTournamentCountRef.current = tournaments.length
+    if (tournaments.length > 0) {
       runAnalysis()
     }
-  }, [tournaments.length, isLoading, runAnalysis])
+  }, [tournaments, runAnalysis])
 
   const runExport = useCallback((charts: ExportChart[], isTournament: boolean) => {
     const html = isTournament

--- a/web/src/components/TournamentCharts.test.tsx
+++ b/web/src/components/TournamentCharts.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { TournamentCharts } from './TournamentCharts'
+import type { TournamentSummary } from '../types'
+import type { BankrollWorkerResult } from '../workers/analysisWorker'
+
+// Plotly needs a real browser; the charts' data is what we assert on.
+vi.mock('./plot', () => ({ default: () => null }))
+
+const viz = vi.hoisted(() => {
+  const empty = () => ({ traces: [], layout: {} })
+  return {
+    getHistoricalPerformanceData: vi.fn(empty),
+    getRREHeatmapData: vi.fn(empty),
+    getPrizePiesData: vi.fn(empty),
+    getRRByRankData: vi.fn(empty),
+    getBankrollAnalysisData: vi.fn(empty),
+  }
+})
+vi.mock('../visualization', () => viz)
+
+function tournament(id: number): TournamentSummary {
+  return {
+    id,
+    name: `T${id}`,
+    buyInPure: 0.9,
+    rake: 0.1,
+    totalPrizePool: 100,
+    startTime: new Date(2026, 0, id),
+    myRank: 1,
+    totalPlayers: 100,
+    myPrize: 5,
+    myEntries: 1,
+  }
+}
+
+/** One result per initial capital — the length never varies, only the rates do. */
+function bankroll(bankruptcyRate: number): BankrollWorkerResult[] {
+  return [10, 20, 50, 100, 200, 500].map(initialCapital => ({
+    initialCapital,
+    bankruptcyRate,
+    survivalRate: 1 - bankruptcyRate,
+  }))
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.clearAllMocks()
+})
+
+async function render(tournaments: TournamentSummary[], bankrollResults: BankrollWorkerResult[]) {
+  await act(async () => {
+    root.render(<TournamentCharts tournaments={tournaments} bankrollResults={bankrollResults} />)
+  })
+}
+
+/** The chart generation yields to the browser between charts, so let it drain. */
+async function settle(timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    let pending = false
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 20))
+      pending = container.querySelector('.chart-loading') !== null
+    })
+    if (!pending) return
+  }
+  throw new Error('chart generation did not finish')
+}
+
+describe('TournamentCharts', () => {
+  // Regression: the bankroll simulation runs in the analysis worker and lands
+  // *after* the parsed tournaments, so a second upload redraws the charts with
+  // the previous run's bankroll results and then gets the fresh ones. Those two
+  // result sets always have the same length, so the component must not decide
+  // "nothing changed" from counts alone.
+  it('redraws the bankroll chart when a later simulation replaces the previous one', async () => {
+    const firstUpload = [tournament(1), tournament(2)]
+    const firstSim = bankroll(0.5)
+
+    await render(firstUpload, firstSim)
+    await settle()
+    expect(viz.getBankrollAnalysisData).toHaveBeenCalledWith(firstSim)
+
+    // Second upload: more tournaments, simulation for them still running.
+    const secondUpload = [...firstUpload, tournament(3)]
+    await render(secondUpload, firstSim)
+    await settle()
+
+    // The new simulation lands — same shape, different numbers.
+    const secondSim = bankroll(0.1)
+    await render(secondUpload, secondSim)
+    await settle()
+
+    expect(viz.getBankrollAnalysisData).toHaveBeenLastCalledWith(secondSim)
+  })
+
+  it('does not recompute when re-rendered with unchanged data', async () => {
+    const tournaments = [tournament(1)]
+    const results = bankroll(0.5)
+
+    await render(tournaments, results)
+    await settle()
+    const callsAfterFirstRender = viz.getHistoricalPerformanceData.mock.calls.length
+
+    await render(tournaments, results)
+    await settle()
+
+    expect(viz.getHistoricalPerformanceData).toHaveBeenCalledTimes(callsAfterFirstRender)
+  })
+})

--- a/web/src/components/TournamentCharts.test.tsx
+++ b/web/src/components/TournamentCharts.test.tsx
@@ -3,10 +3,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { TournamentCharts } from './TournamentCharts'
+import { makeTournament, makeBankrollResults } from '../test/fixtures'
 import type { TournamentSummary } from '../types'
 import type { BankrollWorkerResult } from '../workers/analysisWorker'
 
-// Plotly needs a real browser; the charts' data is what we assert on.
+// Plotly needs a real browser; the chart *data* is what we assert on.
 vi.mock('./plot', () => ({ default: () => null }))
 
 const viz = vi.hoisted(() => {
@@ -21,29 +22,21 @@ const viz = vi.hoisted(() => {
 })
 vi.mock('../visualization', () => viz)
 
-function tournament(id: number): TournamentSummary {
+// Chart generation parks on yieldToBrowser() between charts. Turning each yield
+// into a gate we open by hand makes the interleaving of two concurrent
+// generations exact, instead of racing real timers.
+const gates = vi.hoisted(() => {
+  let waiting: Array<() => void> = []
   return {
-    id,
-    name: `T${id}`,
-    buyInPure: 0.9,
-    rake: 0.1,
-    totalPrizePool: 100,
-    startTime: new Date(2026, 0, id),
-    myRank: 1,
-    totalPlayers: 100,
-    myPrize: 5,
-    myEntries: 1,
+    yieldToBrowser: vi.fn(() => new Promise<void>(resolve => waiting.push(resolve))),
+    open: () => {
+      const opening = waiting
+      waiting = []
+      opening.forEach(resolve => resolve())
+    },
   }
-}
-
-/** One result per initial capital — the length never varies, only the rates do. */
-function bankroll(bankruptcyRate: number): BankrollWorkerResult[] {
-  return [10, 20, 50, 100, 200, 500].map(initialCapital => ({
-    initialCapital,
-    bankruptcyRate,
-    survivalRate: 1 - bankruptcyRate,
-  }))
-}
+})
+vi.mock('../utils', () => ({ yieldToBrowser: gates.yieldToBrowser }))
 
 let container: HTMLDivElement
 let root: Root
@@ -67,18 +60,27 @@ async function render(tournaments: TournamentSummary[], bankrollResults: Bankrol
   })
 }
 
-/** The chart generation yields to the browser between charts, so let it drain. */
-async function settle(timeoutMs = 5000) {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    let pending = false
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 20))
-      pending = container.querySelector('.chart-loading') !== null
-    })
-    if (!pending) return
+/** The component shows its progress bar for as long as it is generating charts. */
+function isComputing(): boolean {
+  return container.querySelector('.chart-loading') !== null
+}
+
+/** Let every parked generation advance to its next yield. */
+async function step() {
+  await act(async () => {
+    gates.open()
+    // The component pulls in ../visualization with a dynamic import, which
+    // settles on a macrotask rather than on a gate.
+    await new Promise(resolve => setTimeout(resolve, 0))
+  })
+}
+
+/** Run generations to completion. Bounded so a stall fails instead of hanging. */
+async function drain(maxSteps = 100) {
+  for (let i = 0; i < maxSteps && isComputing(); i++) {
+    await step()
   }
-  throw new Error('chart generation did not finish')
+  if (isComputing()) throw new Error('chart generation did not finish')
 }
 
 describe('TournamentCharts', () => {
@@ -88,37 +90,57 @@ describe('TournamentCharts', () => {
   // result sets always have the same length, so the component must not decide
   // "nothing changed" from counts alone.
   it('redraws the bankroll chart when a later simulation replaces the previous one', async () => {
-    const firstUpload = [tournament(1), tournament(2)]
-    const firstSim = bankroll(0.5)
+    const firstUpload = [makeTournament(1), makeTournament(2)]
+    const firstSim = makeBankrollResults(0.5)
 
     await render(firstUpload, firstSim)
-    await settle()
+    await drain()
     expect(viz.getBankrollAnalysisData).toHaveBeenCalledWith(firstSim)
 
     // Second upload: more tournaments, simulation for them still running.
-    const secondUpload = [...firstUpload, tournament(3)]
+    const secondUpload = [...firstUpload, makeTournament(3)]
     await render(secondUpload, firstSim)
-    await settle()
+    await drain()
 
     // The new simulation lands — same shape, different numbers.
-    const secondSim = bankroll(0.1)
+    const secondSim = makeBankrollResults(0.1)
     await render(secondUpload, secondSim)
-    await settle()
+    await drain()
 
     expect(viz.getBankrollAnalysisData).toHaveBeenLastCalledWith(secondSim)
   })
 
-  it('does not recompute when re-rendered with unchanged data', async () => {
-    const tournaments = [tournament(1)]
-    const results = bankroll(0.5)
+  // Regression: a superseded generation must not report "Complete". It captured
+  // the old props, so letting it clear the progress bar would also drop the
+  // export's still-calculating guard while the newest charts are still missing.
+  it('keeps reporting progress when a superseded generation finishes late', async () => {
+    const tournaments = [makeTournament(1)]
 
-    await render(tournaments, results)
-    await settle()
-    const callsAfterFirstRender = viz.getHistoricalPerformanceData.mock.calls.length
+    // First upload: the charts are generated while the bankroll simulation is
+    // still running in the worker, so there are no results to draw yet. Advance
+    // that generation to its last chart, where only the final yield is left.
+    await render(tournaments, [])
+    for (let i = 0; i < 20 && viz.getRRByRankData.mock.calls.length === 0; i++) {
+      await step()
+    }
+    expect(viz.getRRByRankData).toHaveBeenCalled()
+    expect(isComputing()).toBe(true)
 
-    await render(tournaments, results)
-    await settle()
+    // The simulation lands, superseding that nearly-finished generation.
+    const sim = makeBankrollResults(0.5)
+    await render(tournaments, sim)
+    expect(isComputing()).toBe(true)
 
-    expect(viz.getHistoricalPerformanceData).toHaveBeenCalledTimes(callsAfterFirstRender)
+    // The superseded generation now runs off the end of its work.
+    await step()
+
+    expect(viz.getBankrollAnalysisData).not.toHaveBeenCalled()
+    expect(isComputing(), 'progress bar cleared while the newest charts were still missing').toBe(
+      true
+    )
+
+    await drain()
+    expect(viz.getBankrollAnalysisData).toHaveBeenCalledWith(sim)
+    expect(isComputing()).toBe(false)
   })
 })

--- a/web/src/components/TournamentCharts.tsx
+++ b/web/src/components/TournamentCharts.tsx
@@ -47,9 +47,8 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
     progress: { message: '', percentage: 0 },
   })
 
-  const abortRef = useRef(false)
-  const lastTournamentCountRef = useRef(0)
-  const lastBankrollCountRef = useRef(0)
+  const computeIdRef = useRef(0)
+  const lastComputedRef = useRef<TournamentChartsProps | null>(null)
 
   useImperativeHandle(ref, () => ({
     getChartData() {
@@ -69,15 +68,19 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
   useEffect(() => {
     if (tournaments.length === 0) return
 
-    // Skip if data hasn't changed (same counts means no new unique data was added)
-    if (
-      tournaments.length === lastTournamentCountRef.current &&
-      bankrollResults.length === lastBankrollCountRef.current
-    ) {
+    // Both arrays keep their identity while their contents are unchanged, so a
+    // reference match means there is nothing new to draw. Counts cannot be used
+    // here: a fresh bankroll simulation always returns one result per initial
+    // capital, so its length is identical even when every number in it changed.
+    const last = lastComputedRef.current
+    if (last && last.tournaments === tournaments && last.bankrollResults === bankrollResults) {
       return
     }
+    lastComputedRef.current = { tournaments, bankrollResults }
 
-    abortRef.current = false
+    // Any compute started later supersedes this one.
+    const thisComputeId = ++computeIdRef.current
+    const isStale = () => computeIdRef.current !== thisComputeId
 
     const compute = async () => {
       setState(prev => ({
@@ -97,7 +100,7 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
           getBankrollAnalysisData,
         } = await import('../visualization')
 
-        if (abortRef.current) return
+        if (isStale()) return
 
         // Historical Performance
         setState(prev => ({
@@ -107,7 +110,7 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
         await yieldToBrowser()
 
         const historical = getHistoricalPerformanceData(tournaments)
-        if (abortRef.current) return
+        if (isStale()) return
 
         setState(prev => ({ ...prev, historical }))
         await yieldToBrowser()
@@ -120,7 +123,7 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
         await yieldToBrowser()
 
         const rre = getRREHeatmapData(tournaments)
-        if (abortRef.current) return
+        if (isStale()) return
 
         setState(prev => ({ ...prev, rre }))
         await yieldToBrowser()
@@ -133,7 +136,7 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
         await yieldToBrowser()
 
         const prizePies = getPrizePiesData(tournaments)
-        if (abortRef.current) return
+        if (isStale()) return
 
         setState(prev => ({ ...prev, prizePies }))
         await yieldToBrowser()
@@ -146,7 +149,7 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
         await yieldToBrowser()
 
         const rrByRank = getRRByRankData(tournaments)
-        if (abortRef.current) return
+        if (isStale()) return
 
         setState(prev => ({ ...prev, rrByRank }))
         await yieldToBrowser()
@@ -160,14 +163,10 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
           await yieldToBrowser()
 
           const bankroll = getBankrollAnalysisData(bankrollResults)
-          if (abortRef.current) return
+          if (isStale()) return
 
           setState(prev => ({ ...prev, bankroll }))
         }
-
-        // Update refs
-        lastTournamentCountRef.current = tournaments.length
-        lastBankrollCountRef.current = bankrollResults.length
 
         setState(prev => ({
           ...prev,
@@ -185,10 +184,6 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
     }
 
     compute()
-
-    return () => {
-      abortRef.current = true
-    }
   }, [tournaments, bankrollResults])
 
   if (tournaments.length === 0) {

--- a/web/src/components/TournamentCharts.tsx
+++ b/web/src/components/TournamentCharts.tsx
@@ -48,7 +48,6 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
   })
 
   const computeIdRef = useRef(0)
-  const lastComputedRef = useRef<TournamentChartsProps | null>(null)
 
   useImperativeHandle(ref, () => ({
     getChartData() {
@@ -65,18 +64,13 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
     },
   }))
 
+  // Both props keep their identity while their contents are unchanged, so the
+  // dependency list alone decides when to redraw. Do not reintroduce a
+  // count-based skip here: a bankroll run always returns one result per initial
+  // capital, so its length is identical even when every number in it changed,
+  // and the fresh results would be dropped.
   useEffect(() => {
     if (tournaments.length === 0) return
-
-    // Both arrays keep their identity while their contents are unchanged, so a
-    // reference match means there is nothing new to draw. Counts cannot be used
-    // here: a fresh bankroll simulation always returns one result per initial
-    // capital, so its length is identical even when every number in it changed.
-    const last = lastComputedRef.current
-    if (last && last.tournaments === tournaments && last.bankrollResults === bankrollResults) {
-      return
-    }
-    lastComputedRef.current = { tournaments, bankrollResults }
 
     // Any compute started later supersedes this one.
     const thisComputeId = ++computeIdRef.current
@@ -168,6 +162,11 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
           setState(prev => ({ ...prev, bankroll }))
         }
 
+        // Without this check a superseded compute would report "Complete" over a
+        // live one, clearing the progress bar and the export's still-calculating
+        // guard while the newest charts are still being generated.
+        if (isStale()) return
+
         setState(prev => ({
           ...prev,
           isComputing: false,
@@ -175,6 +174,8 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
         }))
       } catch (error) {
         console.error('Chart generation failed:', error)
+        if (isStale()) return
+
         setState(prev => ({
           ...prev,
           isComputing: false,
@@ -184,6 +185,14 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
     }
 
     compute()
+
+    return () => {
+      // Supersede the in-flight compute on unmount / prop change. Reading the
+      // ref's latest value here is the intent, not a stale-capture mistake, so
+      // the rule's "copy it into a variable" advice does not apply.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      computeIdRef.current++
+    }
   }, [tournaments, bankrollResults])
 
   if (tournaments.length === 0) {

--- a/web/src/hooks/useAnalysisWorker.test.ts
+++ b/web/src/hooks/useAnalysisWorker.test.ts
@@ -1,68 +1,39 @@
 import { describe, it, expect } from 'vitest'
 import { mergeTournaments, mergeHandHistories } from './useAnalysisWorker'
-import type { TournamentSummary, HandHistory } from '../types'
+import { makeTournament, makeHandHistory } from '../test/fixtures'
 
-function tournament(id: number, startTime: string): TournamentSummary {
-  return {
-    id,
-    name: `T${id}`,
-    buyInPure: 0.9,
-    rake: 0.1,
-    totalPrizePool: 100,
-    startTime: new Date(startTime),
-    myRank: 1,
-    totalPlayers: 100,
-    myPrize: 5,
-    myEntries: 1,
-  }
-}
-
-function handHistory(id: string, datetime: string): HandHistory {
-  return {
-    id,
-    tournamentId: 1,
-    tournamentName: 'T1',
-    level: 1,
-    sb: 10,
-    bb: 20,
-    datetime: new Date(datetime),
-    buttonSeat: 1,
-    sbSeat: 2,
-    bbSeat: 3,
-    maxSeats: 9,
-    seats: new Map(),
-    knownCards: new Map(),
-    wons: new Map(),
-  } as HandHistory
-}
+const at = (day: number) => new Date(2026, 0, day)
 
 describe('mergeTournaments', () => {
   it('appends new tournaments and keeps them sorted by start time', () => {
-    const existing = [tournament(1, '2026-01-01')]
-    const merged = mergeTournaments(existing, [tournament(3, '2026-01-03'), tournament(2, '2026-01-02')])
+    const existing = [makeTournament(1, { startTime: at(1) })]
+    const merged = mergeTournaments(existing, [
+      makeTournament(3, { startTime: at(3) }),
+      makeTournament(2, { startTime: at(2) }),
+    ])
 
     expect(merged.map(t => t.id)).toEqual([1, 2, 3])
   })
 
   it('drops tournaments whose ID is already present', () => {
-    const existing = [tournament(1, '2026-01-01')]
-    const merged = mergeTournaments(existing, [tournament(1, '2026-01-01'), tournament(2, '2026-01-02')])
+    const existing = [makeTournament(1)]
+    const merged = mergeTournaments(existing, [makeTournament(1), makeTournament(2)])
 
     expect(merged.map(t => t.id)).toEqual([1, 2])
   })
 
-  // Downstream chart code treats a changed array identity as "the data changed",
-  // so a merge that adds nothing must not hand back a fresh array.
+  // TournamentCharts treats a changed array identity as "the data changed", so a
+  // merge that adds nothing must not hand back a fresh array.
   it('returns the existing array itself when nothing new is added', () => {
-    const existing = [tournament(1, '2026-01-01')]
+    const existing = [makeTournament(1)]
 
     expect(mergeTournaments(existing, [])).toBe(existing)
-    expect(mergeTournaments(existing, [tournament(1, '2026-01-01')])).toBe(existing)
+    expect(mergeTournaments(existing, [makeTournament(1)])).toBe(existing)
   })
 
-  it('returns a new array when something is added', () => {
-    const existing = [tournament(1, '2026-01-01')]
-    const merged = mergeTournaments(existing, [tournament(2, '2026-01-02')])
+  it('returns a new array, leaving the existing one untouched, when something is added', () => {
+    const existing = [makeTournament(1)]
+    const merged = mergeTournaments(existing, [makeTournament(2)])
 
     expect(merged).not.toBe(existing)
     expect(existing).toHaveLength(1)
@@ -71,19 +42,19 @@ describe('mergeTournaments', () => {
 
 describe('mergeHandHistories', () => {
   it('appends new hands and keeps them sorted by time', () => {
-    const existing = [handHistory('TM1', '2026-01-01')]
+    const existing = [makeHandHistory('TM1', { datetime: at(1) })]
     const merged = mergeHandHistories(existing, [
-      handHistory('TM3', '2026-01-03'),
-      handHistory('TM2', '2026-01-02'),
+      makeHandHistory('TM3', { datetime: at(3) }),
+      makeHandHistory('TM2', { datetime: at(2) }),
     ])
 
     expect(merged.map(h => h.id)).toEqual(['TM1', 'TM2', 'TM3'])
   })
 
   it('returns the existing array itself when nothing new is added', () => {
-    const existing = [handHistory('TM1', '2026-01-01')]
+    const existing = [makeHandHistory('TM1')]
 
     expect(mergeHandHistories(existing, [])).toBe(existing)
-    expect(mergeHandHistories(existing, [handHistory('TM1', '2026-01-01')])).toBe(existing)
+    expect(mergeHandHistories(existing, [makeHandHistory('TM1')])).toBe(existing)
   })
 })

--- a/web/src/hooks/useAnalysisWorker.test.ts
+++ b/web/src/hooks/useAnalysisWorker.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { mergeTournaments, mergeHandHistories } from './useAnalysisWorker'
+import type { TournamentSummary, HandHistory } from '../types'
+
+function tournament(id: number, startTime: string): TournamentSummary {
+  return {
+    id,
+    name: `T${id}`,
+    buyInPure: 0.9,
+    rake: 0.1,
+    totalPrizePool: 100,
+    startTime: new Date(startTime),
+    myRank: 1,
+    totalPlayers: 100,
+    myPrize: 5,
+    myEntries: 1,
+  }
+}
+
+function handHistory(id: string, datetime: string): HandHistory {
+  return {
+    id,
+    tournamentId: 1,
+    tournamentName: 'T1',
+    level: 1,
+    sb: 10,
+    bb: 20,
+    datetime: new Date(datetime),
+    buttonSeat: 1,
+    sbSeat: 2,
+    bbSeat: 3,
+    maxSeats: 9,
+    seats: new Map(),
+    knownCards: new Map(),
+    wons: new Map(),
+  } as HandHistory
+}
+
+describe('mergeTournaments', () => {
+  it('appends new tournaments and keeps them sorted by start time', () => {
+    const existing = [tournament(1, '2026-01-01')]
+    const merged = mergeTournaments(existing, [tournament(3, '2026-01-03'), tournament(2, '2026-01-02')])
+
+    expect(merged.map(t => t.id)).toEqual([1, 2, 3])
+  })
+
+  it('drops tournaments whose ID is already present', () => {
+    const existing = [tournament(1, '2026-01-01')]
+    const merged = mergeTournaments(existing, [tournament(1, '2026-01-01'), tournament(2, '2026-01-02')])
+
+    expect(merged.map(t => t.id)).toEqual([1, 2])
+  })
+
+  // Downstream chart code treats a changed array identity as "the data changed",
+  // so a merge that adds nothing must not hand back a fresh array.
+  it('returns the existing array itself when nothing new is added', () => {
+    const existing = [tournament(1, '2026-01-01')]
+
+    expect(mergeTournaments(existing, [])).toBe(existing)
+    expect(mergeTournaments(existing, [tournament(1, '2026-01-01')])).toBe(existing)
+  })
+
+  it('returns a new array when something is added', () => {
+    const existing = [tournament(1, '2026-01-01')]
+    const merged = mergeTournaments(existing, [tournament(2, '2026-01-02')])
+
+    expect(merged).not.toBe(existing)
+    expect(existing).toHaveLength(1)
+  })
+})
+
+describe('mergeHandHistories', () => {
+  it('appends new hands and keeps them sorted by time', () => {
+    const existing = [handHistory('TM1', '2026-01-01')]
+    const merged = mergeHandHistories(existing, [
+      handHistory('TM3', '2026-01-03'),
+      handHistory('TM2', '2026-01-02'),
+    ])
+
+    expect(merged.map(h => h.id)).toEqual(['TM1', 'TM2', 'TM3'])
+  })
+
+  it('returns the existing array itself when nothing new is added', () => {
+    const existing = [handHistory('TM1', '2026-01-01')]
+
+    expect(mergeHandHistories(existing, [])).toBe(existing)
+    expect(mergeHandHistories(existing, [handHistory('TM1', '2026-01-01')])).toBe(existing)
+  })
+})

--- a/web/src/hooks/useAnalysisWorker.ts
+++ b/web/src/hooks/useAnalysisWorker.ts
@@ -32,27 +32,36 @@ export interface AnalysisState {
 }
 
 /**
- * Merge tournaments, deduplicating by tournament ID
+ * Merge tournaments, deduplicating by tournament ID and sorting by start time.
+ * Returns `existing` itself when nothing new was added, so consumers can treat a
+ * changed array identity as "the data really changed".
  */
-function mergeTournaments(
+export function mergeTournaments(
   existing: TournamentSummary[],
   newItems: TournamentSummary[]
 ): TournamentSummary[] {
   const existingIds = new Set(existing.map(t => t.id))
   const uniqueNew = newItems.filter(t => !existingIds.has(t.id))
-  return [...existing, ...uniqueNew]
+  if (uniqueNew.length === 0) return existing
+  return [...existing, ...uniqueNew].sort(
+    (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+  )
 }
 
 /**
- * Merge hand histories, deduplicating by hand ID
+ * Merge hand histories, deduplicating by hand ID and sorting by time.
+ * Preserves the existing array's identity when nothing new was added.
  */
-function mergeHandHistories(
+export function mergeHandHistories(
   existing: HandHistory[],
   newItems: HandHistory[]
 ): HandHistory[] {
   const existingIds = new Set(existing.map(h => h.id))
   const uniqueNew = newItems.filter(h => !existingIds.has(h.id))
-  return [...existing, ...uniqueNew]
+  if (uniqueNew.length === 0) return existing
+  return [...existing, ...uniqueNew].sort(
+    (a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime()
+  )
 }
 
 export interface UseAnalysisWorkerReturn extends AnalysisState {
@@ -111,24 +120,14 @@ export function useAnalysisWorker(): UseAnalysisWorkerReturn {
         } else if (result.parseResult) {
           // Parse result - merge with existing data, deduplicating by ID
           setState(prev => {
-            const mergedTournaments = mergeTournaments(prev.tournaments, result.parseResult!.tournaments)
-            const mergedHH = mergeHandHistories(prev.handHistories, result.parseResult!.handHistories)
-
-            // Sort by time
-            mergedTournaments.sort(
-              (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
-            )
-            mergedHH.sort(
-              (a, b) => new Date(a.datetime).getTime() - new Date(b.datetime).getTime()
-            )
-
+            const parsed = result.parseResult!
             return {
               ...prev,
               isLoading: false,
               progress: null,
-              tournaments: mergedTournaments,
-              handHistories: mergedHH,
-              errors: [...prev.errors, ...result.parseResult!.errors],
+              tournaments: mergeTournaments(prev.tournaments, parsed.tournaments),
+              handHistories: mergeHandHistories(prev.handHistories, parsed.handHistories),
+              errors: [...prev.errors, ...parsed.errors],
               wasmVersion: result.wasmVersion || prev.wasmVersion,
             }
           })

--- a/web/src/test/fixtures.ts
+++ b/web/src/test/fixtures.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared fixtures for tests.
+ */
+
+import type { TournamentSummary, HandHistory } from '../types'
+import type { BankrollWorkerResult } from '../workers/analysisWorker'
+
+export function makeTournament(
+  id: number,
+  overrides: Partial<TournamentSummary> = {}
+): TournamentSummary {
+  return {
+    id,
+    name: `T${id}`,
+    buyInPure: 0.9,
+    rake: 0.1,
+    totalPrizePool: 100,
+    startTime: new Date(2026, 0, id),
+    myRank: 1,
+    totalPlayers: 100,
+    myPrize: 5,
+    myEntries: 1,
+    ...overrides,
+  }
+}
+
+export function makeHandHistory(
+  id: string,
+  overrides: Partial<HandHistory> = {}
+): HandHistory {
+  return {
+    id,
+    tournamentId: 1,
+    tournamentName: 'T1',
+    level: 1,
+    sb: 10,
+    bb: 20,
+    datetime: new Date(2026, 0, 1),
+    buttonSeat: 1,
+    sbSeat: 2,
+    bbSeat: 3,
+    maxSeats: 9,
+    seats: new Map(),
+    knownCards: new Map(),
+    wons: new Map(),
+    communityCards: [],
+    actionsPreflop: [],
+    actionsFlop: [],
+    actionsTurn: [],
+    actionsRiver: [],
+    uncalledReturned: null,
+    allIned: new Map(),
+    ...overrides,
+  }
+}
+
+/**
+ * A bankroll run always returns one result per initial capital, so the length is
+ * fixed and only the rates vary between runs.
+ */
+export function makeBankrollResults(bankruptcyRate: number): BankrollWorkerResult[] {
+  return [10, 20, 50, 100, 200, 500].map(initialCapital => ({
+    initialCapital,
+    bankruptcyRate,
+    survivalRate: 1 - bankruptcyRate,
+  }))
+}


### PR DESCRIPTION
## Problem

Bankroll analysis appeared to run only for the first batch of tournament results. The simulation itself *was* re-running on every upload — but `TournamentCharts` never redrew the chart with the new results, so the chart kept showing the numbers computed from the first upload.

## Root cause

The chart-regeneration effect skipped work by comparing input **lengths**:

```ts
if (tournaments.length === lastTournamentCountRef.current &&
    bankrollResults.length === lastBankrollCountRef.current) return
```

A bankroll run always returns one result per initial capital (10/20/50/100/200/500 → 6 entries), so its length is identical even when every number in it changed. On a second upload:

1. The parsed tournaments land first → the guard passes (tournament count grew) → charts regenerate, but the new simulation is still running, so the bankroll chart is drawn from the **previous** results and `lastBankrollCountRef` is recorded as 6.
2. The fresh simulation arrives → effect fires → guard sees `6 === 6` plus the already-recorded tournament count → **early return**. The new results are silently dropped.

The same guard also allowed two chart generations to race: the effect cleanup set the shared `abortRef`, and the immediate re-run reset it to `false`, so a superseded generation could finish last and win with its stale bankroll data.

## Fix

- **`TournamentCharts.tsx`** — compare inputs by identity instead of by length, and supersede in-flight generations with a monotonic compute id (`isStale()`), the pattern `HandHistoryCharts` already uses.
- **`useAnalysisWorker.ts`** — `mergeTournaments` / `mergeHandHistories` now return the *existing* array when a parse adds nothing new, which makes array identity a truthful "the data changed" signal. Sorting moved into the merge, dropping an in-place `.sort()` of React state.
- **`App.tsx`** — the auto-run effect used the same fragile count comparison; it now keys on the tournaments array identity.

## Tests

- `TournamentCharts.test.tsx` replays the real upload sequence (parse #2 lands → charts redraw with stale bankroll → fresh simulation arrives) and asserts the chart is drawn from the newest results. Verified that it **fails against the pre-fix component** and passes with the fix.
- `useAnalysisWorker.test.ts` covers the merge dedup/sort behaviour and the identity-preservation contract the fix depends on.
- Adds `jsdom` as a devDependency — there was no DOM test environment, so React effect-ordering bugs like this one were previously untestable.

Full suite: 57 passing. `npm run build` clean; lint unchanged from the `master` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)