### PR TITLE
Ignore local Claude Code config and skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ target/
 
 # Open source tools to analyze
 open_sources/
+
+# Claude Code local config and skills
+.claude/settings.local.json
+.claude/skills/


### PR DESCRIPTION
Adds `.claude/settings.local.json` and `.claude/skills/` to `.gitignore` — both are per-developer local state rather than project configuration, and they currently show up as untracked noise in `git status`.

Note this deliberately does *not* ignore all of `.claude/`, so a shared `.claude/settings.json` can still be committed later if we want one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)