### PR TITLE
Keep sub-1% rank percentile ticks distinguishable

### DIFF
--- a/web/src/visualization/tournament/rrByRank.ts
+++ b/web/src/visualization/tournament/rrByRank.ts
@@ -116,7 +116,9 @@ export function getRRByRankData(tournaments: TournamentSummary[]): RRByRankData 
     xaxis: {
       title: { text: 'Rank Percentile' },
       type: 'log',
-      tickformat: ',.0%',
+      // Significant-digit percent (`p`) with trailing zeros trimmed (`~`), so deep runs
+      // stay distinguishable: 0.1% / 0.01% instead of both collapsing to "0%" under `.0%`.
+      tickformat: ',.3~p',
       range: [0, log10OrNaN(minPercentile) - 0.2],
       autorange: false,
     },


### PR DESCRIPTION
## Problem

The x-axis of **RR by Rank Percentile** is log scale, but its `tickformat` was `,.0%` — zero decimal places. Every tick below 0.5% rounded to `0%`, so the axis ended in a run of identical labels:

```
100%, 50%, 20%, 10%, 5%, 2%, 1%, 0%, 0%, 0%, 0%, 0%
```

A 3/10,000 deep run (0.03%) and a 4/1,300 one (0.31%) were indistinguishable by label, which defeats the purpose of the log scale for exactly the tournaments it exists to show.

## Fix

One-line change to `,.3~p`. The `p` format type rounds to **significant digits** rather than decimal places, so each decade of the log axis keeps its precision automatically; `~` trims padding zeros so the common ticks stay short (`50%`, not `50.0%`).

```
100%, 50%, 20%, 10%, 5%, 2%, 1%, 0.5%, 0.2%, 0.1%, 0.05%, 0.02%
```

A 1-in-100,000 finish would read `0.001%`. No new dependency: plotly 3.3.1 bundles d3-format 1.4.5, which supports both the `p` type and the `~` trim flag.

## Verification

- Rendered the chart in jsdom with the reported scenario (3/10,000 and 4/1,300 in one dataset) and read the tick labels back out of the SVG — output is the corrected list above, with no duplicate labels.
- Confirmed in the dev server against real tournament data.
- `tsc --noEmit` clean; all 57 existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)