### PR TITLE
Compute each hand's equity once, and show the user when a chart fails

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -352,6 +352,18 @@
   color: #666;
 }
 
+/* Chart Failure State — shown independently of the progress bar, which only exists
+   while work is still outstanding. */
+.chart-error {
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+  background: #2a1a1a;
+  border: 1px solid #5a2a2a;
+  border-radius: 12px;
+  color: #f2a0a0;
+  text-align: center;
+}
+
 /* Chart Loading State */
 .chart-loading {
   padding: 2rem;

--- a/web/src/components/HandHistoryCharts.test.tsx
+++ b/web/src/components/HandHistoryCharts.test.tsx
@@ -55,8 +55,11 @@ const equity = vi.hoisted(() => {
     inFlight: () => release !== null,
   }
 })
-vi.mock('../visualization/handHistory/allInEquityAsync', () => equity)
-vi.mock('../visualization/handHistory/equityStore', () => equity)
+vi.mock('../visualization/handHistory/equityStore', () => ({ loadEquity: equity.loadEquity }))
+vi.mock('../visualization/handHistory/allInEquityAsync', () => ({
+  calculateLuckScore: equity.calculateLuckScore,
+  createAllInEquityChart: equity.createAllInEquityChart,
+}))
 
 const gates = vi.hoisted(() => {
   let waiting: Array<() => void> = []
@@ -75,9 +78,8 @@ let container: HTMLDivElement
 let root: Root
 let ref: RefObject<HandHistoryChartsRef | null>
 
-// The equity store is module-level and survives between tests, so every test needs hand
-// ids of its own — otherwise the second test finds the first test's equity already there.
 let idSeq = 0
+/** Fresh ids per test, so nothing can accidentally depend on another test's hands. */
 function makeHands(count: number): HandHistory[] {
   const batch = ++idSeq
   return Array.from({ length: count }, (_, i) => ({ id: `t${batch}-h${i}` }) as HandHistory)
@@ -197,6 +199,33 @@ describe('HandHistoryCharts', () => {
     expect(viz.getChipHistoriesData).toHaveBeenCalledTimes(1)
     expect(viz.getHandUsageHeatmapsData).toHaveBeenCalledTimes(1)
     expect(chartNames()).toEqual([NAME.chips, NAME.usage, NAME.equity])
+  })
+
+  // A failure has to be shown — writing it into the progress state, as the component used
+  // to, meant the very act of reporting it unmounted the block that displayed it. And it
+  // has to be *dropped* once the layer that raised it recovers: the figure layers rerun
+  // on every language switch, so a banner that outlived its cause would be permanent.
+  it('shows a failure, and clears it when that layer succeeds again', async () => {
+    viz.getChipHistoriesData.mockRejectedValueOnce(new Error('boom'))
+
+    await render(makeHands(3))
+    await stepUntilEquityInFlight()
+    await landEquity()
+    await drain()
+
+    const banner = () => container.querySelector('.chart-error')?.textContent ?? null
+    expect(banner()).toBe(i18n.t('charts.buildFailed'))
+    // The failure is confined to its own layer: the equity chart still made it.
+    expect(chartNames()).toContain(NAME.equity)
+
+    // A language switch reruns the figure layers. This time they succeed.
+    await act(async () => {
+      await i18n.changeLanguage('ko')
+    })
+    await drain()
+
+    expect(banner(), 'the banner outlived the failure that caused it').toBeNull()
+    expect(chartNames()).toHaveLength(3)
   })
 
   it('settles with every figure present, and reports idle', async () => {

--- a/web/src/components/HandHistoryCharts.test.tsx
+++ b/web/src/components/HandHistoryCharts.test.tsx
@@ -33,9 +33,9 @@ vi.mock('../visualization', () => viz)
 const equity = vi.hoisted(() => {
   let release: ((data: Array<{ handId: string }>) => void) | null = null
   return {
-    collectAllInDataAsync: vi.fn(
+    loadEquity: vi.fn(
       () => new Promise(resolve => {
-        release = data => resolve({ data })
+        release = data => resolve(data)
       })
     ),
     calculateLuckScore: vi.fn(async () => 1.5),
@@ -56,6 +56,7 @@ const equity = vi.hoisted(() => {
   }
 })
 vi.mock('../visualization/handHistory/allInEquityAsync', () => equity)
+vi.mock('../visualization/handHistory/equityStore', () => equity)
 
 const gates = vi.hoisted(() => {
   let waiting: Array<() => void> = []
@@ -74,8 +75,8 @@ let container: HTMLDivElement
 let root: Root
 let ref: RefObject<HandHistoryChartsRef | null>
 
-// `equityCache` is module-level and survives between tests, so every test needs hand ids
-// of its own — otherwise the second test finds the first test's equity already cached.
+// The equity store is module-level and survives between tests, so every test needs hand
+// ids of its own — otherwise the second test finds the first test's equity already there.
 let idSeq = 0
 function makeHands(count: number): HandHistory[] {
   const batch = ++idSeq
@@ -158,7 +159,7 @@ describe('HandHistoryCharts', () => {
     await drain()
 
     expect(isIdle()).toBe(true)
-    expect(equity.collectAllInDataAsync).toHaveBeenCalledTimes(1)
+    expect(equity.loadEquity).toHaveBeenCalledTimes(1)
 
     await act(async () => {
       await i18n.changeLanguage('ko')
@@ -172,7 +173,7 @@ describe('HandHistoryCharts', () => {
 
     expect(isIdle()).toBe(true)
     // The expensive pass ran once, for the upload. The switch did not touch it.
-    expect(equity.collectAllInDataAsync).toHaveBeenCalledTimes(1)
+    expect(equity.loadEquity).toHaveBeenCalledTimes(1)
     // All three figures were rebuilt in the new language.
     expect(viz.getChipHistoriesData).toHaveBeenCalledTimes(2)
     expect(viz.getHandUsageHeatmapsData).toHaveBeenCalledTimes(2)

--- a/web/src/components/HandHistoryCharts.tsx
+++ b/web/src/components/HandHistoryCharts.tsx
@@ -72,9 +72,6 @@ export interface HandHistoryChartsRef {
   isComputing: () => boolean
 }
 
-// Global cache for equity results (persists across re-renders)
-const equityCache = new Map<string, AllInHandData>()
-
 export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryChartsProps>(
   function HandHistoryCharts({ handHistories }, ref) {
   const { t, i18n } = useTranslation()
@@ -90,6 +87,11 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
   > | null>(null)
   const [equityFigure, setEquityFigure] = useState<Built<ChartData, EquityData> | null>(null)
   const [drawProgress, setDrawProgress] = useState<Progress>({ messageKey: null, percentage: 0 })
+
+  // Kept apart from `progress`, because the progress block only renders while work is
+  // outstanding — so writing a failure into it was exactly what hid the failure. The
+  // only trace a user got of a broken chart was a console line they never opened.
+  const [error, setError] = useState<TranslationKey | null>(null)
 
   const calcIdRef = useRef(0)
   const handsIdRef = useRef(0)
@@ -161,50 +163,29 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
 
     const calculate = async () => {
       setIsCalculating(true)
+      setError(null)
       setDataProgress({ messageKey: 'progress.chart.equityCache', percentage: 25 })
       await yieldToBrowser()
 
       try {
-        const { collectAllInDataAsync, calculateLuckScore } = await import(
-          '../visualization/handHistory/allInEquityAsync'
-        )
+        const [{ loadEquity }, { calculateLuckScore }] = await Promise.all([
+          import('../visualization/handHistory/equityStore'),
+          import('../visualization/handHistory/allInEquityAsync'),
+        ])
         if (isStale()) return
 
-        const uncachedHands = handHistories.filter(h => !equityCache.has(h.id))
-        const cachedCount = handHistories.length - uncachedHands.length
-
-        if (uncachedHands.length > 0) {
-          setDataProgress({
-            messageKey: 'progress.chart.equityCached',
-            messageParams: { cached: cachedCount, pending: uncachedHands.length },
-            percentage: 30,
-          })
-
-          const { data: newAllInData } = await collectAllInDataAsync(
-            uncachedHands,
-            (current, total) => {
-              if (isStale()) return
-              setDataProgress({
-                messageKey: 'progress.chart.equity',
-                messageParams: { current, total },
-                percentage: 30 + Math.floor((current / total) * 55),
-              })
-            }
-          )
-
-          // Bank before the staleness check. Equity is keyed by hand id and does not
-          // depend on which pass produced it, so results are always worth keeping —
-          // returning first would throw away every hand this pass already paid WASM
-          // for, and a pass does get superseded, by a second upload landing mid-pass.
-          for (const data of newAllInData) {
-            equityCache.set(data.handId, data)
-          }
+        // `loadEquity` owns both the cache and the record of what is currently being
+        // computed, so this pass never re-does a hand that an earlier, still-running
+        // pass is already working on — it waits for it instead.
+        const allInData = await loadEquity(handHistories, (current, total) => {
           if (isStale()) return
-        }
-
-        const allInData = handHistories
-          .map(h => equityCache.get(h.id))
-          .filter((d): d is AllInHandData => d !== undefined)
+          setDataProgress({
+            messageKey: 'progress.chart.equity',
+            messageParams: { current, total },
+            percentage: 30 + Math.floor((current / total) * 55),
+          })
+        })
+        if (isStale()) return
 
         // Luck is scored over every loaded hand, not just the latest batch.
         const luckScore = await calculateLuckScore(allInData)
@@ -216,12 +197,12 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
         setDrawProgress({ messageKey: 'progress.chart.allInEquity', percentage: 90 })
         setEquity({ allInData, luckScore })
         setIsCalculating(false)
-      } catch (error) {
-        console.error('Equity calculation failed:', error)
+      } catch (err) {
+        console.error('Equity calculation failed:', err)
         if (isStale()) return
         lastComputedRef.current = new Set() // Allow a retry on the next upload
         setIsCalculating(false)
-        setDataProgress({ messageKey: 'progress.chart.error', percentage: 0 })
+        setError('charts.equityFailed')
       }
     }
 
@@ -270,10 +251,10 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
           from: handHistories,
           language,
         })
-      } catch (error) {
-        console.error('Chart generation failed:', error)
+      } catch (err) {
+        console.error('Chart generation failed:', err)
         if (isStale()) return
-        setDrawProgress({ messageKey: 'progress.chart.error', percentage: 0 })
+        setError('charts.buildFailed')
       }
     }
 
@@ -305,10 +286,10 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
         if (isStale()) return
 
         setEquityFigure({ figure, from: equity, language })
-      } catch (error) {
-        console.error('All-in equity chart failed:', error)
+      } catch (err) {
+        console.error('All-in equity chart failed:', err)
         if (isStale()) return
-        setDrawProgress({ messageKey: 'progress.chart.error', percentage: 0 })
+        setError('charts.buildFailed')
       }
     }
 
@@ -344,6 +325,12 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
 
   return (
     <div className="charts-container">
+      {error && (
+        <div className="chart-error" role="alert">
+          <p>{t(error)}</p>
+        </div>
+      )}
+
       {isComputing && (
         <div className="chart-loading">
           <div className="progress-bar">

--- a/web/src/components/HandHistoryCharts.tsx
+++ b/web/src/components/HandHistoryCharts.tsx
@@ -49,6 +49,9 @@ interface Progress {
   percentage: number
 }
 
+/** The three things this component computes, each of which can fail on its own. */
+type Layer = 'data' | 'handFigures' | 'equityFigure'
+
 /** The language-independent output of the equity pass. */
 interface EquityData {
   allInData: AllInHandData[]
@@ -91,7 +94,25 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
   // Kept apart from `progress`, because the progress block only renders while work is
   // outstanding — so writing a failure into it was exactly what hid the failure. The
   // only trace a user got of a broken chart was a console line they never opened.
-  const [error, setError] = useState<TranslationKey | null>(null)
+  //
+  // Per layer, not one shared slot: each layer retries independently (a language switch
+  // reruns the figures but not the equity pass), so a shared slot would either leave a
+  // failure on screen after the layer that raised it had recovered, or let a recovering
+  // layer wipe another layer's still-live failure.
+  const [failures, setFailures] = useState<Partial<Record<Layer, TranslationKey>>>({})
+
+  const fail = (layer: Layer, message: TranslationKey) =>
+    setFailures(prev => ({ ...prev, [layer]: message }))
+
+  const clearFailure = (layer: Layer) =>
+    setFailures(prev => {
+      if (!(layer in prev)) return prev // keep identity, so this cannot loop a render
+      const next = { ...prev }
+      delete next[layer]
+      return next
+    })
+
+  const failureMessages = [...new Set(Object.values(failures))]
 
   const calcIdRef = useRef(0)
   const handsIdRef = useRef(0)
@@ -114,7 +135,14 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
     equity !== null &&
     (equityFigure === null || equityFigure.from !== equity || equityFigure.language !== language)
 
-  const isComputing = isCalculating || handFiguresStale || equityFigureStale
+  // A layer that has failed is not "outstanding" — it is finished, badly. Counting it as
+  // still working would leave the progress bar spinning under the error banner for the
+  // rest of the session, and hold the export gate shut on charts that are never coming.
+  // The banner says what is missing; the user can still export what did build.
+  const isComputing =
+    isCalculating ||
+    (handFiguresStale && !failures.handFigures) ||
+    (equityFigureStale && !failures.equityFigure)
 
   // The equity pass is the slow one, so its message is the one worth showing while it
   // runs. The bar itself is derived rather than taken from whichever layer wrote last:
@@ -163,7 +191,7 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
 
     const calculate = async () => {
       setIsCalculating(true)
-      setError(null)
+      clearFailure('data')
       setDataProgress({ messageKey: 'progress.chart.equityCache', percentage: 25 })
       await yieldToBrowser()
 
@@ -202,7 +230,7 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
         if (isStale()) return
         lastComputedRef.current = new Set() // Allow a retry on the next upload
         setIsCalculating(false)
-        setError('charts.equityFailed')
+        fail('data', 'charts.equityFailed')
       }
     }
 
@@ -227,6 +255,7 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
     const isStale = () => handsIdRef.current !== thisId
 
     const draw = async () => {
+      clearFailure('handFigures')
       setDrawProgress({ messageKey: 'progress.chart.loadingModules', percentage: 5 })
       await yieldToBrowser()
 
@@ -254,7 +283,7 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
       } catch (err) {
         console.error('Chart generation failed:', err)
         if (isStale()) return
-        setError('charts.buildFailed')
+        fail('handFigures', 'charts.buildFailed')
       }
     }
 
@@ -276,6 +305,7 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
     const isStale = () => equityIdRef.current !== thisId
 
     const draw = async () => {
+      clearFailure('equityFigure')
       try {
         const { createAllInEquityChart } = await import(
           '../visualization/handHistory/allInEquityAsync'
@@ -289,7 +319,7 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
       } catch (err) {
         console.error('All-in equity chart failed:', err)
         if (isStale()) return
-        setError('charts.buildFailed')
+        fail('equityFigure', 'charts.buildFailed')
       }
     }
 
@@ -325,9 +355,11 @@ export const HandHistoryCharts = forwardRef<HandHistoryChartsRef, HandHistoryCha
 
   return (
     <div className="charts-container">
-      {error && (
+      {failureMessages.length > 0 && (
         <div className="chart-error" role="alert">
-          <p>{t(error)}</p>
+          {failureMessages.map(message => (
+            <p key={message}>{t(message)}</p>
+          ))}
         </div>
       )}
 

--- a/web/src/components/TournamentCharts.tsx
+++ b/web/src/components/TournamentCharts.tsx
@@ -30,6 +30,7 @@ interface ChartsState {
   rrByRank: ChartData | null
   isComputing: boolean
   progress: { messageKey: TranslationKey | null; percentage: number }
+  error: TranslationKey | null
 }
 
 export interface TournamentChartsRef {
@@ -48,6 +49,7 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
     rrByRank: null,
     isComputing: false,
     progress: { messageKey: null, percentage: 0 },
+    error: null,
   })
 
   const computeIdRef = useRef(0)
@@ -89,6 +91,7 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
       setState(prev => ({
         ...prev,
         isComputing: true,
+        error: null,
         progress: { messageKey: 'progress.chart.loadingModules', percentage: 5 },
       }))
 
@@ -181,15 +184,13 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
           isComputing: false,
           progress: { messageKey: 'progress.chart.complete', percentage: 100 },
         }))
-      } catch (error) {
-        console.error('Chart generation failed:', error)
+      } catch (err) {
+        console.error('Chart generation failed:', err)
         if (isStale()) return
 
-        setState(prev => ({
-          ...prev,
-          isComputing: false,
-          progress: { messageKey: 'progress.chart.error', percentage: 0 },
-        }))
+        // Not into `progress`: that block only renders while work is outstanding, so
+        // writing the failure there was exactly what hid it.
+        setState(prev => ({ ...prev, isComputing: false, error: 'charts.buildFailed' }))
       }
     }
 
@@ -216,6 +217,12 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
 
   return (
     <div className="charts-container">
+      {state.error && (
+        <div className="chart-error" role="alert">
+          <p>{t(state.error)}</p>
+        </div>
+      )}
+
       {state.isComputing && (
         <div className="chart-loading">
           <div className="progress-bar">

--- a/web/src/i18n/callSites.test.ts
+++ b/web/src/i18n/callSites.test.ts
@@ -33,6 +33,19 @@ function placeholders(value: string): Set<string> {
 }
 
 /**
+ * Blank out comments, preserving offsets so every index below still lines up.
+ *
+ * Without this a key merely *mentioned* in a comment counts as used — which would let the
+ * unused-key check stay green over a key nothing renders, and these comments discuss keys
+ * by name constantly.
+ */
+function withoutComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, m => m.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) => lead + ' '.repeat(m.length - lead.length))
+}
+
+/**
  * Top-level property names of the object literal starting at `open`.
  *
  * Tracks brace depth so nested objects stay out of the way, tracks paren/bracket depth
@@ -105,7 +118,7 @@ function callSites(): CallSite[] {
   const found: CallSite[] = []
 
   for (const file of sourceFiles(SRC)) {
-    const source = readFileSync(file, 'utf8')
+    const source = withoutComments(readFileSync(file, 'utf8'))
 
     for (const match of source.matchAll(/['"]([\w.]+)['"]/g)) {
       const key = match[1]

--- a/web/src/i18n/callSites.test.ts
+++ b/web/src/i18n/callSites.test.ts
@@ -155,6 +155,15 @@ describe('translation key usages', () => {
     expect(byKey('charts.noHandHistoryData')).toEqual(new Set())
   })
 
+  // A key nobody uses is worse than clutter: translators spend real effort on it, and it
+  // is invisible — the type system only checks the other direction, that a key used
+  // exists. Every key here is named as a literal somewhere (including the ones that
+  // travel as `messageKey` data), so anything unreferenced is genuinely dead.
+  it('has no key that the source never names', () => {
+    const used = new Set(sites.map(s => s.key))
+    expect(Object.keys(en).filter(key => !used.has(key))).toEqual([])
+  })
+
   it('passes exactly the values each key interpolates', () => {
     const wrong: string[] = []
     for (const { file, key, values } of sites) {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -61,9 +61,9 @@
   "progress.chart.complete": "Complete",
 
   "charts.noTournamentData": "No tournament data loaded",
+  "charts.noHandHistoryData": "No hand history data loaded",
   "charts.buildFailed": "Some charts could not be generated. See the browser console for details.",
   "charts.equityFailed": "All-in equity could not be calculated. See the browser console for details.",
-  "charts.noHandHistoryData": "No hand history data loaded",
 
   "chart.historical.name": "Historical Performance",
   "chart.historical.title": "Historical Performance",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -57,12 +57,12 @@
   "progress.chart.handUsage": "Generating hand usage heatmaps...",
   "progress.chart.equityCache": "Checking equity cache...",
   "progress.chart.allInEquity": "Generating all-in equity...",
-  "progress.chart.equityCached": "Found {{cached}} cached, calculating {{pending}} new...",
   "progress.chart.equity": "Calculating equity: {{current}}/{{total}} all-ins...",
   "progress.chart.complete": "Complete",
-  "progress.chart.error": "Error generating charts",
 
   "charts.noTournamentData": "No tournament data loaded",
+  "charts.buildFailed": "Some charts could not be generated. See the browser console for details.",
+  "charts.equityFailed": "All-in equity could not be calculated. See the browser console for details.",
   "charts.noHandHistoryData": "No hand history data loaded",
 
   "chart.historical.name": "Historical Performance",

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -61,9 +61,9 @@
   "progress.chart.complete": "완료",
 
   "charts.noTournamentData": "불러온 토너먼트 데이터가 없습니다",
+  "charts.noHandHistoryData": "불러온 핸드 히스토리 데이터가 없습니다",
   "charts.buildFailed": "일부 차트를 생성하지 못했습니다. 자세한 내용은 브라우저 콘솔을 확인해주세요.",
   "charts.equityFailed": "올인 에퀴티를 계산하지 못했습니다. 자세한 내용은 브라우저 콘솔을 확인해주세요.",
-  "charts.noHandHistoryData": "불러온 핸드 히스토리 데이터가 없습니다",
 
   "chart.historical.name": "과거 성적",
   "chart.historical.title": "과거 성적",

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -57,12 +57,12 @@
   "progress.chart.handUsage": "핸드 사용 히트맵을 생성하는 중...",
   "progress.chart.equityCache": "에퀴티 캐시를 확인하는 중...",
   "progress.chart.allInEquity": "올인 에퀴티 차트를 생성하는 중...",
-  "progress.chart.equityCached": "캐시 {{cached}}개 발견, {{pending}}개 새로 계산하는 중...",
   "progress.chart.equity": "에퀴티 계산 중: 올인 {{current}}/{{total}}...",
   "progress.chart.complete": "완료",
-  "progress.chart.error": "차트 생성 중 오류가 발생했습니다",
 
   "charts.noTournamentData": "불러온 토너먼트 데이터가 없습니다",
+  "charts.buildFailed": "일부 차트를 생성하지 못했습니다. 자세한 내용은 브라우저 콘솔을 확인해주세요.",
+  "charts.equityFailed": "올인 에퀴티를 계산하지 못했습니다. 자세한 내용은 브라우저 콘솔을 확인해주세요.",
   "charts.noHandHistoryData": "불러온 핸드 히스토리 데이터가 없습니다",
 
   "chart.historical.name": "과거 성적",

--- a/web/src/visualization/handHistory/allInEquityAsync.ts
+++ b/web/src/visualization/handHistory/allInEquityAsync.ts
@@ -122,6 +122,15 @@ function filterEligibleHands(handHistories: HandHistory[]): EligibleHand[] {
 }
 
 /**
+ * How long a worker may go without saying anything before it is presumed dead.
+ *
+ * Generous: it has to load a 686 KB preflop cache and instantiate WASM before its first
+ * message, and a hand on a slow machine is nowhere near this. What it bounds is silence,
+ * not work — the timer restarts on every message.
+ */
+const WORKER_SILENCE_LIMIT_MS = 60_000
+
+/**
  * Calculate equity using multiple parallel Web Workers
  */
 export async function collectAllInDataAsync(
@@ -175,13 +184,38 @@ export async function collectAllInDataAsync(
         { type: 'module' }
       )
 
+      // A worker that dies without a word — the browser OOM-killing one of eight, each
+      // holding a 686 KB cache and a WASM instance, is the realistic way — fires neither
+      // `message` nor `onerror`. Without this, its promise simply never settles: no
+      // result, no rejection, no error to catch, and the progress bar spins for the rest
+      // of the session. So treat a long enough silence as death.
+      let watchdog: ReturnType<typeof setTimeout>
+      const die = (reason: string) => {
+        clearTimeout(watchdog)
+        worker.terminate()
+        reject(new Error(reason))
+      }
+      const settle = () => clearTimeout(watchdog)
+      // Reset on every sign of life, so the limit is on *silence*, not on total runtime —
+      // a genuinely long batch keeps reporting progress and is never mistaken for dead.
+      const heardFrom = () => {
+        clearTimeout(watchdog)
+        watchdog = setTimeout(
+          () => die(`Equity worker ${workerIndex} stopped responding`),
+          WORKER_SILENCE_LIMIT_MS
+        )
+      }
+      heardFrom()
+
       worker.onmessage = (event: MessageEvent<EquityWorkerOutput>) => {
         const msg = event.data
+        heardFrom()
 
         if (msg.type === 'progress') {
           progressPerWorker[workerIndex] = msg.current
           updateProgress()
         } else if (msg.type === 'result') {
+          settle()
           worker.terminate()
           // Aggregate stats
           if (msg.stats) {
@@ -194,12 +228,14 @@ export async function collectAllInDataAsync(
             allInStreet: d.allInStreet as HandStage,
           })))
         } else if (msg.type === 'error') {
+          settle()
           worker.terminate()
           reject(new Error(msg.message))
         }
       }
 
       worker.onerror = (error) => {
+        settle()
         worker.terminate()
         reject(error)
       }

--- a/web/src/visualization/handHistory/equityStore.test.ts
+++ b/web/src/visualization/handHistory/equityStore.test.ts
@@ -9,13 +9,24 @@ const collect = vi.hoisted(() => {
   // A queue, not a single slot: the whole point of these tests is two passes being in
   // flight at once, and a single slot would have the second clobber the first.
   const pending: Array<() => void> = []
+  const progress: Array<((c: number, t: number) => void) | undefined> = []
   return {
     calls,
-    fn: vi.fn(async (hands: HandHistory[]) => {
+    /** Drive the progress callback of the oldest pass still in flight. */
+    report(current: number, total: number) {
+      progress[0]?.(current, total)
+    },
+    fn: vi.fn(async (hands: HandHistory[], onProgress?: (c: number, t: number) => void) => {
       calls.push(hands.map(h => h.id))
+      // Faithful to the real thing: only all-in hands yield a result. A mock that
+      // returned data for everything would hide the fact that a hand which never had an
+      // all-in is never cached, and so is offered again on every call.
+      const eligible = hands.filter(h => h.id.startsWith('allin'))
+      if (eligible.length === 0) return { data: [] }
+      progress.push(onProgress)
       await new Promise<void>(resolve => pending.push(resolve))
       return {
-        data: hands.map(h => ({
+        data: eligible.map(h => ({
           handId: h.id,
           equity: 0.5,
           actualResult: 1,
@@ -32,6 +43,7 @@ const collect = vi.hoisted(() => {
     reset() {
       calls.length = 0
       pending.length = 0
+      progress.length = 0
     },
   }
 })
@@ -43,7 +55,20 @@ vi.mock('./allInEquityAsync', async importOriginal => {
 
 const { loadEquity, resetEquityStore } = await import('./equityStore')
 
-const hand = (id: string) => ({ id }) as HandHistory
+/** An all-in hand — the kind that actually produces equity. */
+const hand = (id: string) => ({ id: `allin-${id}` }) as HandHistory
+
+/** A hand with no all-in, which never yields a result and so is never cached. */
+const fold = (id: string) => ({ id: `fold-${id}` }) as HandHistory
+
+/**
+ * Let deferred passes actually start.
+ *
+ * `loadEquity` claims its hands synchronously and only *then* lets the pass run, on a
+ * microtask — so that the claim is unconditionally first, rather than first by accident
+ * of how much `collectAllInDataAsync` happens to do before its own first await.
+ */
+const tick = () => Promise.resolve()
 
 beforeEach(() => {
   resetEquityStore()
@@ -58,13 +83,14 @@ afterEach(() => {
 describe('loadEquity', () => {
   it('computes the hands it is given, and caches them', async () => {
     const load = loadEquity([hand('a'), hand('b')])
+    await tick()
     collect.finish()
     expect(await load).toHaveLength(2)
-    expect(collect.calls).toEqual([['a', 'b']])
+    expect(collect.calls).toEqual([['allin-a', 'allin-b']])
 
     // Second call: everything is cached, so nothing is computed again.
     expect(await loadEquity([hand('a'), hand('b')])).toHaveLength(2)
-    expect(collect.calls).toEqual([['a', 'b']])
+    expect(collect.calls).toEqual([['allin-a', 'allin-b']])
   })
 
   // The bug this store exists for. The cache is only written once a whole batch resolves,
@@ -74,13 +100,15 @@ describe('loadEquity', () => {
   it('does not recompute hands that an in-flight pass is already working on', async () => {
     const first = loadEquity([hand('a'), hand('b')])
 
-    // A second upload lands: the same two hands, plus a new one.
+    // A second upload lands, mid-pass: the same two hands, plus a new one. The claims are
+    // already in place, even though neither pass has begun running.
     const second = loadEquity([hand('a'), hand('b'), hand('c')])
+    await tick()
 
     // Only 'c' is handed to a new pass. 'a' and 'b' are awaited, not redone.
     expect(collect.calls).toEqual([
-      ['a', 'b'],
-      ['c'],
+      ['allin-a', 'allin-b'],
+      ['allin-c'],
     ])
 
     collect.finish() // first pass
@@ -90,20 +118,57 @@ describe('loadEquity', () => {
     expect(await second).toHaveLength(3)
     // Still exactly two passes: no hand was computed twice.
     expect(collect.calls).toEqual([
-      ['a', 'b'],
-      ['c'],
+      ['allin-a', 'allin-b'],
+      ['allin-c'],
     ])
   })
 
   it('waits for an in-flight pass rather than returning a hand as missing', async () => {
     const first = loadEquity([hand('a')])
     const second = loadEquity([hand('a')]) // identical, while the first is still running
+    await tick()
 
-    expect(collect.calls).toEqual([['a']]) // one pass, not two
+    expect(collect.calls).toEqual([['allin-a']]) // one pass, not two
 
     collect.finish()
     expect(await first).toHaveLength(1)
     expect(await second).toHaveLength(1) // resolved from the pass it waited on
+  })
+
+  // Reported progress must cover every pass the caller is waiting on, not just the one it
+  // started. Otherwise a caller that joined someone else's pass would show a bar frozen on
+  // its own completed count while the pass holding the hands it needs ground on invisibly.
+  it('reports progress across every pass it is waiting on, not just its own', async () => {
+    const seen: Array<[number, number]> = []
+
+    const first = loadEquity([hand('a'), hand('b')])
+    await tick()
+
+    // A second call joins that pass and adds one new hand of its own.
+    const second = loadEquity([hand('a'), hand('b'), hand('c')], (c, t) => seen.push([c, t]))
+    await tick()
+
+    // The joined pass moves. The joiner hears about it, even though it did not start it.
+    collect.report(1, 2)
+    expect(seen.at(-1)).toEqual([1, 2])
+
+    collect.finish()
+    collect.finish()
+    await Promise.all([first, second])
+  })
+
+  // Hands that never had an all-in produce no result and so are never cached — they are
+  // re-offered on every call. That must cost nothing, and must not wedge anything.
+  it('re-offers hands with no all-in without spawning work for them', async () => {
+    const load = loadEquity([hand('a'), fold('x')])
+    await tick()
+    collect.finish()
+    expect(await load).toHaveLength(1) // only the all-in yields equity
+
+    // Second call: the all-in is cached, so only the fold is offered — and it needs no
+    // worker, so this resolves without anything having to be finished.
+    expect(await loadEquity([hand('a'), fold('x')])).toHaveLength(1)
+    expect(collect.calls).toEqual([['allin-a', 'fold-x'], ['fold-x']])
   })
 
   // Otherwise a transient failure would leave the hands claimed forever, and every later
@@ -114,6 +179,7 @@ describe('loadEquity', () => {
 
     // The retry actually recomputes rather than hanging on the dead claim.
     const retry = loadEquity([hand('a')])
+    await tick()
     collect.finish()
     expect(await retry).toHaveLength(1)
   })

--- a/web/src/visualization/handHistory/equityStore.test.ts
+++ b/web/src/visualization/handHistory/equityStore.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { HandHistory } from '../../types'
+
+// `loadEquity` is the deduplicating layer over this. Standing in for it lets a test hold
+// a "pass" open and start a second one while the first is still running — which is the
+// race the store exists to close, and which real Web Workers make impossible to arrange.
+const collect = vi.hoisted(() => {
+  const calls: string[][] = []
+  // A queue, not a single slot: the whole point of these tests is two passes being in
+  // flight at once, and a single slot would have the second clobber the first.
+  const pending: Array<() => void> = []
+  return {
+    calls,
+    fn: vi.fn(async (hands: HandHistory[]) => {
+      calls.push(hands.map(h => h.id))
+      await new Promise<void>(resolve => pending.push(resolve))
+      return {
+        data: hands.map(h => ({
+          handId: h.id,
+          equity: 0.5,
+          actualResult: 1,
+          allInStreet: 'preflop',
+        })),
+      }
+    }),
+    /** Let the oldest pass still in flight finish. */
+    finish() {
+      const resolve = pending.shift()
+      if (!resolve) throw new Error('no pass in flight')
+      resolve()
+    },
+    reset() {
+      calls.length = 0
+      pending.length = 0
+    },
+  }
+})
+
+vi.mock('./allInEquityAsync', async importOriginal => {
+  const actual = await importOriginal<typeof import('./allInEquityAsync')>()
+  return { ...actual, collectAllInDataAsync: collect.fn }
+})
+
+const { loadEquity, resetEquityStore } = await import('./equityStore')
+
+const hand = (id: string) => ({ id }) as HandHistory
+
+beforeEach(() => {
+  resetEquityStore()
+  collect.reset()
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  resetEquityStore()
+})
+
+describe('loadEquity', () => {
+  it('computes the hands it is given, and caches them', async () => {
+    const load = loadEquity([hand('a'), hand('b')])
+    collect.finish()
+    expect(await load).toHaveLength(2)
+    expect(collect.calls).toEqual([['a', 'b']])
+
+    // Second call: everything is cached, so nothing is computed again.
+    expect(await loadEquity([hand('a'), hand('b')])).toHaveLength(2)
+    expect(collect.calls).toEqual([['a', 'b']])
+  })
+
+  // The bug this store exists for. The cache is only written once a whole batch resolves,
+  // so a second upload landing mid-pass used to see every in-flight hand as uncached and
+  // start a *second* pool of up to 8 unabortable workers on hands the first pool was
+  // already grinding — both pools then fighting for the CPU over the same WASM.
+  it('does not recompute hands that an in-flight pass is already working on', async () => {
+    const first = loadEquity([hand('a'), hand('b')])
+
+    // A second upload lands: the same two hands, plus a new one.
+    const second = loadEquity([hand('a'), hand('b'), hand('c')])
+
+    // Only 'c' is handed to a new pass. 'a' and 'b' are awaited, not redone.
+    expect(collect.calls).toEqual([
+      ['a', 'b'],
+      ['c'],
+    ])
+
+    collect.finish() // first pass
+    collect.finish() // the pass for 'c'
+
+    expect(await first).toHaveLength(2)
+    expect(await second).toHaveLength(3)
+    // Still exactly two passes: no hand was computed twice.
+    expect(collect.calls).toEqual([
+      ['a', 'b'],
+      ['c'],
+    ])
+  })
+
+  it('waits for an in-flight pass rather than returning a hand as missing', async () => {
+    const first = loadEquity([hand('a')])
+    const second = loadEquity([hand('a')]) // identical, while the first is still running
+
+    expect(collect.calls).toEqual([['a']]) // one pass, not two
+
+    collect.finish()
+    expect(await first).toHaveLength(1)
+    expect(await second).toHaveLength(1) // resolved from the pass it waited on
+  })
+
+  // Otherwise a transient failure would leave the hands claimed forever, and every later
+  // attempt would await a promise that already rejected.
+  it('releases its claim when a pass fails, so the hands can be retried', async () => {
+    collect.fn.mockRejectedValueOnce(new Error('WASM exploded'))
+    await expect(loadEquity([hand('a')])).rejects.toThrow('WASM exploded')
+
+    // The retry actually recomputes rather than hanging on the dead claim.
+    const retry = loadEquity([hand('a')])
+    collect.finish()
+    expect(await retry).toHaveLength(1)
+  })
+})

--- a/web/src/visualization/handHistory/equityStore.ts
+++ b/web/src/visualization/handHistory/equityStore.ts
@@ -1,29 +1,43 @@
 /**
  * The store of computed all-in equity.
  *
- * All-in equity is the one genuinely expensive thing the app does: `collectAllInDataAsync`
- * spawns a pool of up to 8 Web Workers, each of which loads a 686 KB preflop cache and
- * initialises WASM, and none of which can be aborted once started. So the rule is that a
- * hand's equity is computed exactly once, ever — and this module is what enforces it.
+ * All-in equity is the one genuinely expensive thing the app does:
+ * `collectAllInDataAsync` spawns a pool of up to 8 Web Workers, each of which loads a
+ * 686 KB preflop cache and initialises WASM, and none of which can be aborted once
+ * started. So the rule is that no hand's equity is ever computed twice — not by a later
+ * upload, and not by an upload that lands while an earlier one is still being worked on.
+ * This module is what enforces that.
+ *
+ * (Hands with no all-in never produce a result, so they are never cached and are re-offered
+ * on every call. That costs nothing: `collectAllInDataAsync` finds none of them eligible
+ * and returns without spawning a worker.)
  */
 
 import type { HandHistory } from '../../types'
 import { collectAllInDataAsync, type AllInHandData } from './allInEquityAsync'
 
+/** A batch of hands currently being computed. */
+interface Pass {
+  promise: Promise<void>
+  /** Live progress, so a caller *waiting* on this pass can report it too. */
+  done: number
+  total: number
+  /** Callers to nudge when the numbers move. */
+  watchers: Set<() => void>
+}
+
 /** Hands whose equity is known. */
 const cache = new Map<string, AllInHandData>()
 
 /**
- * Hands whose equity is being computed *right now*, and the pass computing them.
+ * Hands being computed *right now*, and the pass computing them.
  *
  * The cache alone is not enough, because it can only be written once a whole batch has
  * resolved. A second upload landing mid-pass would therefore see every in-flight hand as
  * uncached and start a *second* worker pool on hands the first pool was already grinding
- * — two unabortable pools fighting over the CPU to compute the same WASM twice. Claiming
- * the hands here, synchronously, before anything is awaited, is what makes that
- * impossible.
+ * — two unabortable pools fighting over the CPU to compute the same WASM twice.
  */
-const inFlight = new Map<string, Promise<void>>()
+const inFlight = new Map<string, Pass>()
 
 /**
  * The equity for every one of `hands` that has any, computing whatever is missing.
@@ -36,19 +50,24 @@ export async function loadEquity(
   onProgress?: (current: number, total: number) => void
 ): Promise<AllInHandData[]> {
   const missing = hands.filter(h => !cache.has(h.id) && !inFlight.has(h.id))
-  const running = [
-    ...new Set(hands.map(h => inFlight.get(h.id)).filter((p): p is Promise<void> => p != null)),
+  const waitingOn = [
+    ...new Set(hands.map(h => inFlight.get(h.id)).filter((p): p is Pass => p != null)),
   ]
 
   if (missing.length > 0) {
-    const pass = (async () => {
-      const { data } = await collectAllInDataAsync(missing, onProgress)
-      for (const d of data) cache.set(d.handId, d)
-    })()
+    const pass: Pass = {
+      // Deferred deliberately. `collectAllInDataAsync` runs synchronously — filtering,
+      // spawning its workers, firing its first `onProgress` — right up to its first
+      // await. Calling it inline would therefore have the pool already up and reporting
+      // before the claims below existed. Nothing can currently observe that gap, but the
+      // claim being *actually* first is the invariant this module rests on, and it should
+      // not depend on an implementation detail of a function in another file.
+      promise: Promise.resolve().then(() => run(pass, missing)),
+      done: 0,
+      total: 0,
+      watchers: new Set(),
+    }
 
-    // Claimed before `pass` yields, so a caller arriving later sees these as taken. A
-    // hand with no equity to compute (not an all-in) simply never lands in the cache;
-    // it is dropped from the result below, which is the same thing.
     for (const h of missing) inFlight.set(h.id, pass)
 
     const release = () => {
@@ -57,15 +76,44 @@ export async function loadEquity(
       }
     }
     // Released on failure too, so a transient error leaves the hands retryable instead of
-    // claimed forever by a pass that will never finish. The caller still sees the
-    // rejection, through the await below.
-    pass.then(release, release)
-    running.push(pass)
+    // claimed forever by a pass that will never finish. Callers still see the rejection,
+    // through the await below.
+    pass.promise.then(release, release)
+
+    waitingOn.push(pass)
   }
 
-  await Promise.all(running)
+  // Report the union of every pass this call is waiting on — including ones it did not
+  // start. Reporting only our own would freeze the bar on a completed count while another
+  // pass, holding hands we need, ground on invisibly.
+  const report = () => {
+    if (!onProgress) return
+    let done = 0
+    let total = 0
+    for (const pass of waitingOn) {
+      done += pass.done
+      total += pass.total
+    }
+    if (total > 0) onProgress(done, total)
+  }
+  for (const pass of waitingOn) pass.watchers.add(report)
+
+  try {
+    await Promise.all(waitingOn.map(p => p.promise))
+  } finally {
+    for (const pass of waitingOn) pass.watchers.delete(report)
+  }
 
   return hands.map(h => cache.get(h.id)).filter((d): d is AllInHandData => d !== undefined)
+}
+
+async function run(pass: Pass, hands: HandHistory[]): Promise<void> {
+  const { data } = await collectAllInDataAsync(hands, (current, total) => {
+    pass.done = current
+    pass.total = total
+    for (const watch of pass.watchers) watch()
+  })
+  for (const d of data) cache.set(d.handId, d)
 }
 
 /** Test seam. Without it, module state would leak between test cases. */

--- a/web/src/visualization/handHistory/equityStore.ts
+++ b/web/src/visualization/handHistory/equityStore.ts
@@ -1,0 +1,75 @@
+/**
+ * The store of computed all-in equity.
+ *
+ * All-in equity is the one genuinely expensive thing the app does: `collectAllInDataAsync`
+ * spawns a pool of up to 8 Web Workers, each of which loads a 686 KB preflop cache and
+ * initialises WASM, and none of which can be aborted once started. So the rule is that a
+ * hand's equity is computed exactly once, ever — and this module is what enforces it.
+ */
+
+import type { HandHistory } from '../../types'
+import { collectAllInDataAsync, type AllInHandData } from './allInEquityAsync'
+
+/** Hands whose equity is known. */
+const cache = new Map<string, AllInHandData>()
+
+/**
+ * Hands whose equity is being computed *right now*, and the pass computing them.
+ *
+ * The cache alone is not enough, because it can only be written once a whole batch has
+ * resolved. A second upload landing mid-pass would therefore see every in-flight hand as
+ * uncached and start a *second* worker pool on hands the first pool was already grinding
+ * — two unabortable pools fighting over the CPU to compute the same WASM twice. Claiming
+ * the hands here, synchronously, before anything is awaited, is what makes that
+ * impossible.
+ */
+const inFlight = new Map<string, Promise<void>>()
+
+/**
+ * The equity for every one of `hands` that has any, computing whatever is missing.
+ *
+ * Safe to call while an earlier call is still running: hands already in flight are waited
+ * for rather than recomputed, and only genuinely new ones are handed to workers.
+ */
+export async function loadEquity(
+  hands: HandHistory[],
+  onProgress?: (current: number, total: number) => void
+): Promise<AllInHandData[]> {
+  const missing = hands.filter(h => !cache.has(h.id) && !inFlight.has(h.id))
+  const running = [
+    ...new Set(hands.map(h => inFlight.get(h.id)).filter((p): p is Promise<void> => p != null)),
+  ]
+
+  if (missing.length > 0) {
+    const pass = (async () => {
+      const { data } = await collectAllInDataAsync(missing, onProgress)
+      for (const d of data) cache.set(d.handId, d)
+    })()
+
+    // Claimed before `pass` yields, so a caller arriving later sees these as taken. A
+    // hand with no equity to compute (not an all-in) simply never lands in the cache;
+    // it is dropped from the result below, which is the same thing.
+    for (const h of missing) inFlight.set(h.id, pass)
+
+    const release = () => {
+      for (const h of missing) {
+        if (inFlight.get(h.id) === pass) inFlight.delete(h.id)
+      }
+    }
+    // Released on failure too, so a transient error leaves the hands retryable instead of
+    // claimed forever by a pass that will never finish. The caller still sees the
+    // rejection, through the await below.
+    pass.then(release, release)
+    running.push(pass)
+  }
+
+  await Promise.all(running)
+
+  return hands.map(h => cache.get(h.id)).filter((d): d is AllInHandData => d !== undefined)
+}
+
+/** Test seam. Without it, module state would leak between test cases. */
+export function resetEquityStore(): void {
+  cache.clear()
+  inFlight.clear()
+}

--- a/web/src/visualization/handHistory/workerWatchdog.test.ts
+++ b/web/src/visualization/handHistory/workerWatchdog.test.ts
@@ -1,0 +1,108 @@
+/**
+ * A worker that dies without a word must not hang the app forever.
+ *
+ * `collectAllInDataAsync` resolves its per-worker promise on a `message` and rejects on an
+ * `error`. A worker killed outright — the browser reclaiming one of eight, each holding a
+ * 686 KB cache and a WASM instance, is the realistic way — fires neither. Its promise then
+ * never settles, and neither does the `Promise.all` over the pool: no result, no rejection,
+ * nothing to catch. The spinner turns for the rest of the session.
+ *
+ * That is bad on its own, and worse now that the equity store dedupes: every later caller
+ * joins the dead pass instead of starting a fresh pool, so what used to self-heal on the
+ * next upload is permanent.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { HandHistory } from '../../types'
+import { makeHandHistory } from '../../test/fixtures'
+
+/** A Worker that accepts work and then says nothing, ever. */
+class SilentWorker {
+  onmessage: ((e: MessageEvent) => void) | null = null
+  onerror: ((e: unknown) => void) | null = null
+  static spawned = 0
+  static terminated = 0
+  constructor() {
+    SilentWorker.spawned++
+  }
+  postMessage() {
+    /* swallowed — this is the point */
+  }
+  terminate() {
+    SilentWorker.terminated++
+  }
+}
+
+/** A hand that really is eligible: Hero all-in preflop, both hands shown at showdown. */
+const allInHand = (id: string): HandHistory =>
+  makeHandHistory(id, {
+    seats: new Map([
+      [1, ['Hero', 1000]],
+      [2, ['villain', 1000]],
+    ]),
+    knownCards: new Map([
+      ['Hero', ['As', 'Kh']],
+      ['villain', ['Qs', 'Qd']],
+    ]),
+    wons: new Map([['Hero', 2000]]),
+    allIned: new Map([['Hero', 'preflop']]),
+    communityCards: ['2c', '3d', '4h', '5s', '9c'],
+  })
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  SilentWorker.spawned = 0
+  SilentWorker.terminated = 0
+  vi.stubGlobal('Worker', SilentWorker)
+  vi.stubGlobal('navigator', { hardwareConcurrency: 2 })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('collectAllInDataAsync, when a worker dies silently', () => {
+  it('gives up on it rather than hanging forever', async () => {
+    const { collectAllInDataAsync } = await import('./allInEquityAsync')
+
+    const pass = collectAllInDataAsync([allInHand('h1')])
+    // Prove the premise: without the watchdog this promise settles neither way.
+    const settled = vi.fn()
+    pass.then(settled, settled)
+
+    expect(SilentWorker.spawned).toBeGreaterThan(0)
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(settled, 'gave up before the worker was plausibly dead').not.toHaveBeenCalled()
+
+    // Past the silence limit, it is presumed dead.
+    await vi.advanceTimersByTimeAsync(40_000)
+    await expect(pass).rejects.toThrow(/stopped responding/)
+    expect(SilentWorker.terminated, 'the dead worker was left running').toBeGreaterThan(0)
+  })
+
+  // The rejection is what lets the store release its claim on those hands — otherwise the
+  // dedup would hand every later caller the same never-settling promise.
+  it('lets the equity store release its claim, so a retry can re-spawn', async () => {
+    const { loadEquity, resetEquityStore } = await import('./equityStore')
+    resetEquityStore()
+
+    const first = loadEquity([allInHand('h1')])
+    const caught = first.catch((e: Error) => e.message)
+    await vi.advanceTimersByTimeAsync(70_000)
+    expect(await caught).toMatch(/stopped responding/)
+
+    const spawnedByFirst = SilentWorker.spawned
+    // The claim is gone, so this starts a fresh pool rather than joining the dead pass.
+    const retry = loadEquity([allInHand('h1')])
+    const retryCaught = retry.catch((e: Error) => e.message)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(SilentWorker.spawned, 'the retry joined the dead pass instead of re-spawning').toBeGreaterThan(
+      spawnedByFirst
+    )
+
+    await vi.advanceTimersByTimeAsync(70_000)
+    expect(await retryCaught).toMatch(/stopped responding/)
+    resetEquityStore()
+  })
+})


### PR DESCRIPTION
The two follow-ups agreed on #30. Both were raised in review there and deliberately kept out of it.

---

## 1. Each hand's equity is computed once, ever

All-in equity is the one genuinely expensive thing the app does: `collectAllInDataAsync` spawns up to **8 Web Workers**, each loading a 686 KB preflop cache and initialising WASM, and **none of them can be aborted** once started.

The cache guarding that was only written once a whole batch resolved. So a second upload landing mid-pass saw every in-flight hand as uncached and could start a **second pool** on hands the first pool was already grinding — two unabortable pools fighting over the CPU to do the same WASM twice.

New `equityStore.ts` owns the cache *and* a record of what is being computed right now, claimed **synchronously, before anything is awaited**. A pass waits for hands another pass already holds rather than recomputing them; only genuinely new hands reach a worker.

Its unit tests demonstrate the race directly. With the in-flight tracking removed, loading `[a, b, c]` while `[a, b]` is still in flight hands the whole lot to a fresh pass:

```
expected [ ['a','b'], ['a','b','c'] ]   // recomputes a and b
to equal [ ['a','b'], ['c']       ]   // only c is new
```

### Being straight about the evidence

**I could not reproduce the duplicate pool in a browser.** Parsing a second upload takes longer than the equity pass takes to finish, so the window never opened — the same *accidentally safe, not safe* shape as the language-switch trigger fixed in #30. The store makes the invariant hold **by construction** rather than by timing.

Measured after the change, with a second upload dropped mid-pass (160 files, 302 all-in hands):

```
equity workers spawned : 16   (8 for batch 1, 8 for batch 2's own new hands)
hands sent to workers  : 302
distinct hands         : 302
recomputed twice       : 0     <-- no hand computed more than once
```

## 2. A failed chart is no longer silent

Both chart components caught their failures, cleared `isComputing`, and wrote `progress.chart.error` into the progress state — but the progress block **only renders while work is outstanding**. So writing the failure there was precisely what unmounted the thing that would have displayed it.

Four catch blocks, all dead ends. The only trace a user got of a broken chart was a `console.error` they never opened.

Failures now have their own state and render as a `role="alert"` banner. Verified by injecting a WASM failure:

```
banner (en): All-in equity could not be calculated. See the browser console for details.
banner (ko): 올인 에퀴티를 계산하지 못했습니다. 자세한 내용은 브라우저 콘솔을 확인해주세요.
role       : alert
```

...while the other charts carry on rendering.

## Also

A test that **no key in `en.json` is unreferenced**. Rewiring the equity path orphaned two keys (`progress.chart.error`, `progress.chart.equityCached`) and I only caught them by hand. Translators should not spend effort on text that nothing displays, and the type system only checks the other direction — that a key *used* exists.

## Verification

`npm run build`, `npm test` — 77 tests / 12 files. Every new test verified to **fail** against the unfixed code. Driven in a browser for both the dedup measurement and the injected failure. Lint unchanged at 7 pre-existing errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)