### PR TITLE
Pin wasm-pack in CI — "latest" silently resolves to 2020 when the API is rate-limited

### DIFF
--- a/.github/workflows/test-web.yml
+++ b/.github/workflows/test-web.yml
@@ -47,10 +47,27 @@ jobs:
 
       # Prebuilt binary. `cargo install wasm-pack` compiles it from source and costs
       # minutes on every run, which is too much for a workflow that gates every PR.
+      #
+      # The version is PINNED, and must stay pinned. `version: 'latest'` asks the action to
+      # resolve the newest release from the GitHub API *unauthenticated* — and on a failure
+      # or a rate limit it does not error, it silently falls back to a hard-coded default:
+      #
+      #     return Promise.resolve(JSON.parse(body).tag_name || 'v0.9.1')
+      #
+      # v0.9.1 is from 2020 and ships a `wasm-opt` that predates the reference-types
+      # proposal, so it cannot even parse the module current Rust emits:
+      #
+      #     [parse exception: Only 1 table definition allowed in MVP]
+      #
+      # The failure is intermittent by construction — it depends on whether an API call is
+      # rate-limited, which is likeliest when two runs fire at once, as `push` and
+      # `pull_request` do for every PR. That is exactly how it presented: one commit, both
+      # events, one green (v0.15.0) and one red (v0.9.1). A rerun would have "fixed" it and
+      # taught us nothing.
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: 'latest'
+          version: 'v0.15.0'
 
       # web/src/wasm/ is generated and gitignored, so tsc cannot resolve the module
       # without this.


### PR DESCRIPTION
CI failed on PR #34 at a commit that touched **only TypeScript and JSON**:

```
[parse exception: Only 1 table definition allowed in MVP (at 0:3538)]
Error: failed to execute `wasm-opt`: exited with exit code: 1
```

## It is not a flake, and a rerun would have hidden it

The tell: the **same commit** went green on `push` and red on `pull_request`. Same code, same workflow, two runs, two outcomes — so the input that differed was not ours.

```
push (green):   Installing wasm-pack v0.15.0 ...
pull_request:   Installing wasm-pack v0.9.1  ...   <- released 2020
```

Both runs ask for `version: 'latest'`. `jetli/wasm-pack-action` resolves that by calling the GitHub releases API **unauthenticated**, and when the call fails it does not error — it falls back to a hard-coded default ([source](https://github.com/jetli/wasm-pack-action/blob/master/src/main.ts)):

```js
return Promise.resolve(JSON.parse(body).tag_name || 'v0.9.1')
```

wasm-pack **v0.9.1** ships a `wasm-opt` that predates the reference-types proposal, so it cannot even *parse* the module current Rust emits — hence the "MVP table" error.

So the failure is intermittent **by construction**: it fires whenever that API call is rate-limited, which is likeliest when two runs start at once — exactly what `push` + `pull_request` do on every PR. Our CI toolchain was being chosen by a rate limit.

A rerun would have gone green and taught us nothing, leaving the trap set for the next PR — or for a deploy.

## Fix

Pin the version. `latest` in CI is precisely the thing that makes a build irreproducible, and here it doesn't even fail loudly — it silently downgrades six years.

## Not changed

`deploy-web.yml` is **not** affected: it uses `cargo install wasm-pack`, which cannot hand you a 2020 build. It is also unpinned, but that's a slower-burning risk (a genuinely new release would have to break something) and belongs in its own change — happy to do it if you want the deploy pinned and sped up too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)