### PR TITLE
Record rolldown in the lockfile's root devDependencies

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -30,6 +30,7 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "jsdom": "^29.1.1",
+        "rolldown": "1.0.3",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^8.0.16",


### PR DESCRIPTION
Housekeeping from #36.

`rolldown` was added to `web/package.json` but not to the `packages[""]` block of `web/package-lock.json`.

**Nothing is broken.** `npm ci` passes and CI is green on master — `rolldown@1.0.3` is already in the lock tree because Vite depends on it, so the new devDep resolves against the entry that is already there. I verified this by running `npm ci` against the committed `package.json` + `package-lock.json` in isolation: 528 packages, clean.

The only consequence is that every local `npm install` rewrites the lock, leaving a dirty working tree. This is the one line that stops that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)