### PR TITLE
Disabled-tab tooltips; parse in its own worker (Deep Dive follow-ups)

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -260,6 +260,48 @@
   cursor: not-allowed;
 }
 
+/* Tooltip explaining why a tab is inert. A CSS `::after` rather than a native `title`, which does
+   not reliably show on a disabled <button>; `:hover` still matches the disabled tab. */
+.chart-tabs .tab[data-tooltip] {
+  position: relative;
+}
+
+.chart-tabs .tab[data-tooltip]:hover::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  /* Above the tab, so it never covers the chart section below. */
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: max-content;
+  max-width: 220px;
+  white-space: normal;
+  text-align: center;
+  background: #333;
+  color: #eee;
+  padding: 0.45rem 0.7rem;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-weight: 400;
+  line-height: 1.35;
+  z-index: 100;
+  pointer-events: none;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.55);
+}
+
+/* Arrow under the bubble, pointing down at the tab. */
+.chart-tabs .tab[data-tooltip]:hover::before {
+  content: '';
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: #333;
+  z-index: 100;
+  pointer-events: none;
+}
+
 .chart-tabs .tab-icon {
   font-size: 1.25rem;
 }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -266,7 +266,8 @@
   position: relative;
 }
 
-.chart-tabs .tab[data-tooltip]:hover::after {
+.chart-tabs .tab[data-tooltip]:hover::after,
+.chart-tabs .tab[data-tooltip]:focus-visible::after {
   content: attr(data-tooltip);
   position: absolute;
   /* Above the tab, so it never covers the chart section below. */
@@ -290,7 +291,8 @@
 }
 
 /* Arrow under the bubble, pointing down at the tab. */
-.chart-tabs .tab[data-tooltip]:hover::before {
+.chart-tabs .tab[data-tooltip]:hover::before,
+.chart-tabs .tab[data-tooltip]:focus-visible::before {
   content: '';
   position: absolute;
   bottom: calc(100% + 4px);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -98,7 +98,10 @@ function App() {
 
   const {
     isLoading,
-    progress,
+    isParsing,
+    isAnalyzing,
+    parseProgress,
+    analyzeProgress,
     tournaments,
     handHistories,
     bankrollResults,
@@ -193,8 +196,8 @@ function App() {
 
       <FileUploader
         onFilesSelected={parseFiles}
-        isLoading={isLoading}
-        progress={progress}
+        isParsing={isParsing}
+        parseProgress={parseProgress}
         tournamentCount={tournaments.length}
         handHistoryCount={handHistories.length}
       />
@@ -229,6 +232,8 @@ function App() {
             ref={tournamentChartsRef}
             tournaments={tournaments}
             bankrollResults={bankrollResults}
+            isAnalyzing={isAnalyzing}
+            analyzeProgress={analyzeProgress}
           />
         </ErrorBoundary>
       </div>

--- a/web/src/components/ChartTabs.test.tsx
+++ b/web/src/components/ChartTabs.test.tsx
@@ -40,10 +40,12 @@ function render(tournamentCount: number, handHistoryCount: number) {
 describe('ChartTabs — disabled-tab tooltips', () => {
   it('explains every disabled tab, per its missing data', () => {
     render(0, 5) // hand histories only
-    expect(tabByLabel('Tournament Summary')!.disabled).toBe(true)
-    expect(tabByLabel('Tournament Summary')!.getAttribute('data-tooltip')).toBe(
-      'Needs tournament results'
-    )
+    const tournament = tabByLabel('Tournament Summary')!
+    // Disabled via aria-disabled (not the `disabled` attribute), so it stays focusable for AT.
+    expect(tournament.getAttribute('aria-disabled')).toBe('true')
+    expect(tournament.getAttribute('data-tooltip')).toBe('Needs tournament results')
+    // The reason is also exposed to assistive tech via aria-label.
+    expect(tournament.getAttribute('aria-label')).toContain('Needs tournament results')
     expect(tabByLabel('Deep Dive')!.getAttribute('data-tooltip')).toBe(
       'Needs both tournament results and hand histories'
     )
@@ -61,7 +63,7 @@ describe('ChartTabs — disabled-tab tooltips', () => {
   it('gives an enabled tab no tooltip', () => {
     render(3, 5) // both present
     const deepDive = tabByLabel('Deep Dive')!
-    expect(deepDive.disabled).toBe(false)
+    expect(deepDive.getAttribute('aria-disabled')).toBeNull()
     expect(deepDive.getAttribute('data-tooltip')).toBeNull()
   })
 })

--- a/web/src/components/ChartTabs.test.tsx
+++ b/web/src/components/ChartTabs.test.tsx
@@ -18,41 +18,50 @@ afterEach(() => {
   container.remove()
 })
 
-function deepDiveButton(): HTMLButtonElement | undefined {
+function tabByLabel(label: string): HTMLButtonElement | undefined {
   return Array.from(container.querySelectorAll('button')).find(b =>
-    b.textContent?.includes('Deep Dive')
+    b.textContent?.includes(label)
   ) as HTMLButtonElement | undefined
 }
 
-describe('ChartTabs — Deep Dive tab', () => {
-  it('is disabled when only one dataset is present', () => {
-    act(() => {
-      root.render(
-        <ChartTabs
-          activeTab="handHistory"
-          onTabChange={() => {}}
-          tournamentCount={0}
-          handHistoryCount={5}
-        />
-      )
-    })
-    const btn = deepDiveButton()
-    expect(btn).toBeDefined()
-    expect(btn!.disabled).toBe(true)
+function render(tournamentCount: number, handHistoryCount: number) {
+  act(() => {
+    root.render(
+      <ChartTabs
+        activeTab="handHistory"
+        onTabChange={() => {}}
+        tournamentCount={tournamentCount}
+        handHistoryCount={handHistoryCount}
+      />
+    )
+  })
+}
+
+describe('ChartTabs — disabled-tab tooltips', () => {
+  it('explains every disabled tab, per its missing data', () => {
+    render(0, 5) // hand histories only
+    expect(tabByLabel('Tournament Summary')!.disabled).toBe(true)
+    expect(tabByLabel('Tournament Summary')!.getAttribute('data-tooltip')).toBe(
+      'Needs tournament results'
+    )
+    expect(tabByLabel('Deep Dive')!.getAttribute('data-tooltip')).toBe(
+      'Needs both tournament results and hand histories'
+    )
   })
 
-  it('is enabled once both datasets are present', () => {
-    act(() => {
-      root.render(
-        <ChartTabs
-          activeTab="handHistory"
-          onTabChange={() => {}}
-          tournamentCount={3}
-          handHistoryCount={5}
-        />
-      )
-    })
-    const btn = deepDiveButton()
-    expect(btn!.disabled).toBe(false)
+  it('explains the hand-history-dependent tabs when only tournaments are present', () => {
+    render(3, 0) // tournaments only
+    expect(tabByLabel('Hand History')!.getAttribute('data-tooltip')).toBe('Needs hand history data')
+    // The situation tab shares the hand-history requirement.
+    expect(tabByLabel('Preflop Situations')!.getAttribute('data-tooltip')).toBe(
+      'Needs hand history data'
+    )
+  })
+
+  it('gives an enabled tab no tooltip', () => {
+    render(3, 5) // both present
+    const deepDive = tabByLabel('Deep Dive')!
+    expect(deepDive.disabled).toBe(false)
+    expect(deepDive.getAttribute('data-tooltip')).toBeNull()
   })
 })

--- a/web/src/components/ChartTabs.tsx
+++ b/web/src/components/ChartTabs.tsx
@@ -84,9 +84,14 @@ export function ChartTabs({
       {tabs.map(tab => (
         <button
           key={tab.id}
+          type="button"
           className={`tab ${activeTab === tab.id ? 'active' : ''} ${!tab.enabled ? 'disabled' : ''}`}
           onClick={() => tab.enabled && onTabChange(tab.id)}
-          disabled={!tab.enabled}
+          // `aria-disabled` rather than `disabled`, so a disabled tab stays focusable: keyboard and
+          // screen-reader users can reach it and hear why it is inert. The visual tooltip is the CSS
+          // `data-tooltip` (shown on hover and focus); `aria-label` carries the same reason to AT.
+          aria-disabled={!tab.enabled || undefined}
+          aria-label={!tab.enabled ? `${t(tab.labelKey)} — ${t(tab.disabledTooltipKey)}` : undefined}
           data-tooltip={!tab.enabled ? t(tab.disabledTooltipKey) : undefined}
         >
           <span className="tab-icon">{tab.icon}</span>

--- a/web/src/components/ChartTabs.tsx
+++ b/web/src/components/ChartTabs.tsx
@@ -1,8 +1,13 @@
 /**
- * Tab navigation for chart sections
+ * Tab navigation for chart sections.
+ *
+ * A tab is disabled until the data it needs is loaded, and carries a hover tooltip (a CSS
+ * `::after`, see App.css) saying which data is missing — a native `title` does not reliably show
+ * on a disabled <button>.
  */
 
 import { useTranslation } from 'react-i18next'
+import type { TranslationKey } from '../i18n'
 
 export type ChartTab = 'tournament' | 'handHistory' | 'situation' | 'deepDive'
 
@@ -22,50 +27,73 @@ export function ChartTabs({
   const { t } = useTranslation()
   const hasTournaments = tournamentCount > 0
   const hasHandHistories = handHistoryCount > 0
-  // The Deep Dive tab joins both datasets, so it stays inert until both are present.
+  // Deep Dive joins both datasets, so it needs both present.
   const hasBoth = hasTournaments && hasHandHistories
 
   if (!hasTournaments && !hasHandHistories) {
     return null
   }
 
+  const tabs: Array<{
+    id: ChartTab
+    icon: string
+    labelKey: TranslationKey
+    enabled: boolean
+    /** Count badge, or null for none. */
+    count: number | null
+    /** Shown on hover while the tab is disabled. */
+    disabledTooltipKey: TranslationKey
+  }> = [
+    {
+      id: 'tournament',
+      icon: '🏆',
+      labelKey: 'tabs.tournament',
+      enabled: hasTournaments,
+      count: hasTournaments ? tournamentCount : null,
+      disabledTooltipKey: 'tabs.tournamentDisabledTooltip',
+    },
+    {
+      id: 'handHistory',
+      icon: '🃏',
+      labelKey: 'tabs.handHistory',
+      enabled: hasHandHistories,
+      count: hasHandHistories ? handHistoryCount : null,
+      disabledTooltipKey: 'tabs.handHistoryDisabledTooltip',
+    },
+    {
+      id: 'situation',
+      icon: '🎯',
+      labelKey: 'tabs.situation',
+      enabled: hasHandHistories,
+      count: hasHandHistories ? handHistoryCount : null,
+      // Same data requirement as the hand-history tab.
+      disabledTooltipKey: 'tabs.handHistoryDisabledTooltip',
+    },
+    {
+      id: 'deepDive',
+      icon: '🤿',
+      labelKey: 'tabs.deepDive',
+      enabled: hasBoth,
+      count: null,
+      disabledTooltipKey: 'tabs.deepDiveDisabledTooltip',
+    },
+  ]
+
   return (
     <nav className="chart-tabs">
-      <button
-        className={`tab ${activeTab === 'tournament' ? 'active' : ''} ${!hasTournaments ? 'disabled' : ''}`}
-        onClick={() => hasTournaments && onTabChange('tournament')}
-        disabled={!hasTournaments}
-      >
-        <span className="tab-icon">🏆</span>
-        <span className="tab-label">{t('tabs.tournament')}</span>
-        {hasTournaments && <span className="tab-count">{tournamentCount}</span>}
-      </button>
-      <button
-        className={`tab ${activeTab === 'handHistory' ? 'active' : ''} ${!hasHandHistories ? 'disabled' : ''}`}
-        onClick={() => hasHandHistories && onTabChange('handHistory')}
-        disabled={!hasHandHistories}
-      >
-        <span className="tab-icon">🃏</span>
-        <span className="tab-label">{t('tabs.handHistory')}</span>
-        {hasHandHistories && <span className="tab-count">{handHistoryCount}</span>}
-      </button>
-      <button
-        className={`tab ${activeTab === 'situation' ? 'active' : ''} ${!hasHandHistories ? 'disabled' : ''}`}
-        onClick={() => hasHandHistories && onTabChange('situation')}
-        disabled={!hasHandHistories}
-      >
-        <span className="tab-icon">🎯</span>
-        <span className="tab-label">{t('tabs.situation')}</span>
-        {hasHandHistories && <span className="tab-count">{handHistoryCount}</span>}
-      </button>
-      <button
-        className={`tab ${activeTab === 'deepDive' ? 'active' : ''} ${!hasBoth ? 'disabled' : ''}`}
-        onClick={() => hasBoth && onTabChange('deepDive')}
-        disabled={!hasBoth}
-      >
-        <span className="tab-icon">🤿</span>
-        <span className="tab-label">{t('tabs.deepDive')}</span>
-      </button>
+      {tabs.map(tab => (
+        <button
+          key={tab.id}
+          className={`tab ${activeTab === tab.id ? 'active' : ''} ${!tab.enabled ? 'disabled' : ''}`}
+          onClick={() => tab.enabled && onTabChange(tab.id)}
+          disabled={!tab.enabled}
+          data-tooltip={!tab.enabled ? t(tab.disabledTooltipKey) : undefined}
+        >
+          <span className="tab-icon">{tab.icon}</span>
+          <span className="tab-label">{t(tab.labelKey)}</span>
+          {tab.count !== null && <span className="tab-count">{tab.count}</span>}
+        </button>
+      ))}
     </nav>
   )
 }

--- a/web/src/components/FileUploader.tsx
+++ b/web/src/components/FileUploader.tsx
@@ -1,5 +1,9 @@
 /**
- * File uploader component with drag & drop and progress indicator
+ * File uploader component with drag & drop and a parse-progress indicator.
+ *
+ * Only *parsing* blocks the drop zone (a second parse must not race the first). The bankroll
+ * simulation runs on its own worker, so during it the drop zone stays open and you can add hand
+ * histories right away — the sim's own progress shows in the tournament tab, next to the charts.
  */
 
 import { useCallback, useState } from 'react'
@@ -8,16 +12,16 @@ import type { AnalysisProgress } from '../hooks/useAnalysisWorker'
 
 interface FileUploaderProps {
   onFilesSelected: (files: FileList | File[]) => void
-  isLoading: boolean
-  progress: AnalysisProgress | null
+  isParsing: boolean
+  parseProgress: AnalysisProgress | null
   tournamentCount: number
   handHistoryCount: number
 }
 
 export function FileUploader({
   onFilesSelected,
-  isLoading,
-  progress,
+  isParsing,
+  parseProgress,
   tournamentCount,
   handHistoryCount,
 }: FileUploaderProps) {
@@ -28,11 +32,11 @@ export function FileUploader({
     (e: React.DragEvent) => {
       e.preventDefault()
       setDragOver(false)
-      if (e.dataTransfer.files.length > 0 && !isLoading) {
+      if (e.dataTransfer.files.length > 0 && !isParsing) {
         onFilesSelected(e.dataTransfer.files)
       }
     },
-    [onFilesSelected, isLoading]
+    [onFilesSelected, isParsing]
   )
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
@@ -46,11 +50,11 @@ export function FileUploader({
 
   const handleFileInput = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (e.target.files && e.target.files.length > 0 && !isLoading) {
+      if (e.target.files && e.target.files.length > 0 && !isParsing) {
         onFilesSelected(e.target.files)
       }
     },
-    [onFilesSelected, isLoading]
+    [onFilesSelected, isParsing]
   )
 
   const hasData = tournamentCount > 0 || handHistoryCount > 0
@@ -58,21 +62,23 @@ export function FileUploader({
   return (
     <section className="file-uploader">
       <div
-        className={`upload-zone ${dragOver ? 'drag-over' : ''} ${isLoading ? 'loading' : ''}`}
+        className={`upload-zone ${dragOver ? 'drag-over' : ''} ${isParsing ? 'loading' : ''}`}
         onDrop={handleDrop}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
       >
-        {isLoading ? (
+        {isParsing ? (
           <div className="progress-container">
             <div className="progress-bar">
               <div
                 className="progress-fill"
-                style={{ width: `${progress?.percentage ?? 0}%` }}
+                style={{ width: `${parseProgress?.percentage ?? 0}%` }}
               />
             </div>
             <p className="progress-message">
-              {progress ? t(progress.messageKey, progress.messageParams) : t('uploader.loading')}
+              {parseProgress
+                ? t(parseProgress.messageKey, parseProgress.messageParams)
+                : t('uploader.loading')}
             </p>
           </div>
         ) : (
@@ -86,7 +92,6 @@ export function FileUploader({
               accept=".txt,.zip"
               onChange={handleFileInput}
               id="file-input"
-              disabled={isLoading}
             />
             <label htmlFor="file-input" className="file-button">
               {t('uploader.chooseFiles')}
@@ -95,7 +100,7 @@ export function FileUploader({
         )}
       </div>
 
-      {hasData && !isLoading && (
+      {hasData && !isParsing && (
         <div className="stats-bar">
           {/* <Trans> rather than a plain t(): languages disagree on where the number
               goes relative to the noun ("5 tournaments" vs "토너먼트 5개"), and only

--- a/web/src/components/TournamentCharts.test.tsx
+++ b/web/src/components/TournamentCharts.test.tsx
@@ -143,4 +143,29 @@ describe('TournamentCharts', () => {
     expect(viz.getBankrollAnalysisData).toHaveBeenCalledWith(sim, expect.any(Function))
     expect(isComputing()).toBe(false)
   })
+
+  it('shows the bankroll-simulation progress below the charts while analyzing', async () => {
+    // While analyzing, the sim message takes priority over any chart-generation message.
+    await act(async () => {
+      root.render(
+        <TournamentCharts
+          tournaments={[makeTournament(1)]}
+          bankrollResults={[]}
+          isAnalyzing={true}
+          analyzeProgress={{
+            stage: 'bankroll',
+            current: 0,
+            total: 1,
+            messageKey: 'progress.bankroll',
+            messageParams: { capital: 10 },
+            percentage: 40,
+          }}
+        />
+      )
+    })
+    const loading = container.querySelector('.chart-loading')
+    expect(loading).not.toBeNull()
+    // The real "Simulating N buy-ins" message (with its interpolated number), not a generic label.
+    expect(loading!.textContent).toContain('10')
+  })
 })

--- a/web/src/components/TournamentCharts.tsx
+++ b/web/src/components/TournamentCharts.tsx
@@ -10,6 +10,7 @@ import type { TournamentSummary } from '../types'
 import type { BankrollWorkerResult } from '../workers/analysisWorker'
 import type { ExportChart } from '../export/htmlExport'
 import type { TranslationKey } from '../i18n'
+import type { AnalysisProgress } from '../hooks/useAnalysisWorker'
 import { yieldToBrowser } from '../utils'
 
 interface ChartData {
@@ -20,6 +21,10 @@ interface ChartData {
 interface TournamentChartsProps {
   tournaments: TournamentSummary[]
   bankrollResults: BankrollWorkerResult[]
+  /** The bankroll simulation (upstream of `bankrollResults`) is running in the analysis worker. */
+  isAnalyzing?: boolean
+  /** Its progress, shown here below the tabs — like the equity progress in the hand-history tab. */
+  analyzeProgress?: AnalysisProgress | null
 }
 
 interface ChartsState {
@@ -39,7 +44,10 @@ export interface TournamentChartsRef {
 }
 
 export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentChartsProps>(
-  function TournamentCharts({ tournaments, bankrollResults }, ref) {
+  function TournamentCharts(
+    { tournaments, bankrollResults, isAnalyzing = false, analyzeProgress = null },
+    ref
+  ) {
   const { t, i18n } = useTranslation()
   const [state, setState] = useState<ChartsState>({
     historical: null,
@@ -223,16 +231,22 @@ export const TournamentCharts = forwardRef<TournamentChartsRef, TournamentCharts
         </div>
       )}
 
-      {state.isComputing && (
+      {/* One loading slot for both upstream phases: the bankroll simulation (analysis worker),
+          then building the figures from its results. */}
+      {(isAnalyzing || state.isComputing) && (
         <div className="chart-loading">
           <div className="progress-bar">
             <div
               className="progress-fill"
-              style={{ width: `${state.progress.percentage}%` }}
+              style={{
+                width: `${isAnalyzing ? (analyzeProgress?.percentage ?? 0) : state.progress.percentage}%`,
+              }}
             />
           </div>
           <p className="progress-message">
-            {state.progress.messageKey && t(state.progress.messageKey)}
+            {isAnalyzing
+              ? analyzeProgress && t(analyzeProgress.messageKey, analyzeProgress.messageParams)
+              : state.progress.messageKey && t(state.progress.messageKey)}
           </p>
         </div>
       )}

--- a/web/src/hooks/useAnalysisWorker.ts
+++ b/web/src/hooks/useAnalysisWorker.ts
@@ -1,5 +1,11 @@
 /**
- * React hook for managing the analysis Web Worker
+ * React hook for managing the analysis Web Workers.
+ *
+ * Two workers, so parsing and the bankroll simulation run independently: after tournament results
+ * are uploaded the bankroll sim runs on the analyze worker, and hand histories dropped in during it
+ * are parsed on the parse worker at the same time (each worker has its own WASM instance) — the
+ * hand-history charts and all-in equity then start without waiting for the sim to finish. Within a
+ * worker, tasks that arrive while it is busy queue and post when it frees.
  */
 
 import { useState, useCallback, useRef, useEffect } from 'react'
@@ -25,8 +31,14 @@ export interface AnalysisProgress {
 }
 
 export interface AnalysisState {
-  isLoading: boolean
-  progress: AnalysisProgress | null
+  /** Files are being read/parsed. The uploader blocks during this (short) phase. */
+  isParsing: boolean
+  /** The bankroll simulation is running. Runs on its own worker, so the uploader stays usable. */
+  isAnalyzing: boolean
+  /** Progress of the current parse — shown in the uploader. */
+  parseProgress: AnalysisProgress | null
+  /** Progress of the bankroll sim — shown in the tournament tab, like equity in the HH tab. */
+  analyzeProgress: AnalysisProgress | null
   tournaments: TournamentSummary[]
   handHistories: HandHistory[]
   equityData: AllInEquityWorkerData[]
@@ -69,14 +81,18 @@ export function mergeHandHistories(
 }
 
 export interface UseAnalysisWorkerReturn extends AnalysisState {
+  /** Derived: any worker task in flight (parse or analyze). Kept for consumers that mean "busy". */
+  isLoading: boolean
   parseFiles: (files: FileList | File[], allowFreerolls?: boolean) => void
   runAnalysis: () => void
   reset: () => void
 }
 
 const initialState: AnalysisState = {
-  isLoading: false,
-  progress: null,
+  isParsing: false,
+  isAnalyzing: false,
+  parseProgress: null,
+  analyzeProgress: null,
   tournaments: [],
   handHistories: [],
   equityData: [],
@@ -85,140 +101,207 @@ const initialState: AnalysisState = {
   wasmVersion: '',
 }
 
+const STARTING_PROGRESS = (messageKey: TranslationKey): AnalysisProgress => ({
+  stage: 'init',
+  current: 0,
+  total: 1,
+  messageKey,
+  percentage: 0,
+})
+
+function toProgress(p: WorkerProgress): AnalysisProgress {
+  return {
+    stage: p.stage,
+    current: p.current,
+    total: p.total,
+    messageKey: p.messageKey,
+    messageParams: p.messageParams,
+    percentage: p.total > 0 ? (p.current / p.total) * 100 : 0,
+  }
+}
+
+function newWorker(): Worker {
+  return new Worker(new URL('../workers/analysisWorker.ts', import.meta.url), { type: 'module' })
+}
+
 export function useAnalysisWorker(): UseAnalysisWorkerReturn {
   const [state, setState] = useState<AnalysisState>(initialState)
-  const workerRef = useRef<Worker | null>(null)
 
-  // Initialize worker
+  // Two independent workers. Each serializes its own tasks; the two run concurrently.
+  const parseWorkerRef = useRef<Worker | null>(null)
+  const analyzeWorkerRef = useRef<Worker | null>(null)
+
+  // Parse worker: files that arrive mid-parse queue here and post when it frees.
+  const parseBusyRef = useRef(false)
+  const pendingFilesRef = useRef<File[]>([])
+  const pendingAllowFreerollsRef = useRef(false)
+  const pumpParseRef = useRef<() => void>(() => {})
+
+  // Analyze worker: a re-analyze requested mid-run is collapsed to one pending flag and re-run
+  // with the latest tournaments when the current sim finishes.
+  const analyzeBusyRef = useRef(false)
+  const reanalyzePendingRef = useRef(false)
+  const tournamentsRef = useRef<TournamentSummary[]>([])
+  const pumpAnalyzeRef = useRef<() => void>(() => {})
+
+  // The set a queued analyze posts — kept current with the merged state.
   useEffect(() => {
-    workerRef.current = new Worker(
-      new URL('../workers/analysisWorker.ts', import.meta.url),
-      { type: 'module' }
-    )
+    tournamentsRef.current = state.tournaments
+  }, [state.tournaments])
 
-    workerRef.current.onmessage = (event: MessageEvent<WorkerProgress | WorkerResult>) => {
+  // Reassigned each render, but closes over only refs/setState, so the once-bound worker callbacks
+  // can call the latest through the ref.
+  pumpParseRef.current = () => {
+    const worker = parseWorkerRef.current
+    if (!worker || parseBusyRef.current || pendingFilesRef.current.length === 0) return
+    const files = pendingFilesRef.current
+    const allowFreerolls = pendingAllowFreerollsRef.current
+    pendingFilesRef.current = []
+    parseBusyRef.current = true
+    setState(prev => ({
+      ...prev,
+      isParsing: true,
+      parseProgress: STARTING_PROGRESS('progress.starting'),
+      errors: [],
+    }))
+    worker.postMessage({ type: 'parse', files, allowFreerolls } as WorkerMessage)
+  }
+
+  pumpAnalyzeRef.current = () => {
+    const worker = analyzeWorkerRef.current
+    if (!worker || analyzeBusyRef.current || !reanalyzePendingRef.current) return
+    reanalyzePendingRef.current = false
+    if (tournamentsRef.current.length === 0) return
+    analyzeBusyRef.current = true
+    setState(prev => ({
+      ...prev,
+      isAnalyzing: true,
+      analyzeProgress: STARTING_PROGRESS('progress.startingAnalysis'),
+    }))
+    worker.postMessage({ type: 'analyze', tournaments: tournamentsRef.current } as WorkerMessage)
+  }
+
+  useEffect(() => {
+    const parseWorker = newWorker()
+    const analyzeWorker = newWorker()
+    parseWorkerRef.current = parseWorker
+    analyzeWorkerRef.current = analyzeWorker
+
+    parseWorker.onmessage = (event: MessageEvent<WorkerProgress | WorkerResult>) => {
       const data = event.data
-
       if (data.type === 'progress') {
-        const progress = data as WorkerProgress
-        setState(prev => ({
-          ...prev,
-          progress: {
-            stage: progress.stage,
-            current: progress.current,
-            total: progress.total,
-            messageKey: progress.messageKey,
-            messageParams: progress.messageParams,
-            percentage: progress.total > 0 ? (progress.current / progress.total) * 100 : 0,
-          },
-        }))
+        setState(prev => ({ ...prev, parseProgress: toProgress(data as WorkerProgress) }))
       } else if (data.type === 'result') {
         const result = data as WorkerResult
-
+        parseBusyRef.current = false
         if (result.error) {
           setState(prev => ({
             ...prev,
-            isLoading: false,
-            progress: null,
+            isParsing: false,
+            parseProgress: null,
             errors: [...prev.errors, result.error!],
           }))
         } else if (result.parseResult) {
-          // Parse result - merge with existing data, deduplicating by ID
           setState(prev => {
             const parsed = result.parseResult!
             return {
               ...prev,
-              isLoading: false,
-              progress: null,
+              isParsing: false,
+              parseProgress: null,
               tournaments: mergeTournaments(prev.tournaments, parsed.tournaments),
               handHistories: mergeHandHistories(prev.handHistories, parsed.handHistories),
               errors: [...prev.errors, ...parsed.errors],
               wasmVersion: result.wasmVersion || prev.wasmVersion,
             }
           })
-        } else {
-          // Analysis result
+        }
+        pumpParseRef.current() // next queued parse, if any
+      }
+    }
+
+    parseWorker.onerror = error => {
+      parseBusyRef.current = false
+      setState(prev => ({
+        ...prev,
+        isParsing: false,
+        parseProgress: null,
+        errors: [...prev.errors, i18n.t('errors.worker', { message: error.message })],
+      }))
+      pumpParseRef.current()
+    }
+
+    analyzeWorker.onmessage = (event: MessageEvent<WorkerProgress | WorkerResult>) => {
+      const data = event.data
+      if (data.type === 'progress') {
+        setState(prev => ({ ...prev, analyzeProgress: toProgress(data as WorkerProgress) }))
+      } else if (data.type === 'result') {
+        const result = data as WorkerResult
+        analyzeBusyRef.current = false
+        if (result.error) {
           setState(prev => ({
             ...prev,
-            isLoading: false,
-            progress: null,
+            isAnalyzing: false,
+            analyzeProgress: null,
+            errors: [...prev.errors, result.error!],
+          }))
+        } else {
+          setState(prev => ({
+            ...prev,
+            isAnalyzing: false,
+            analyzeProgress: null,
             equityData: result.equityData || prev.equityData,
             bankrollResults: result.bankrollResults || prev.bankrollResults,
           }))
         }
+        pumpAnalyzeRef.current() // re-run if the set changed mid-sim
       }
     }
 
-    workerRef.current.onerror = (error) => {
+    analyzeWorker.onerror = error => {
+      analyzeBusyRef.current = false
       setState(prev => ({
         ...prev,
-        isLoading: false,
-        progress: null,
+        isAnalyzing: false,
+        analyzeProgress: null,
         errors: [...prev.errors, i18n.t('errors.worker', { message: error.message })],
       }))
+      pumpAnalyzeRef.current()
     }
 
+    // Flush anything queued before the workers existed.
+    pumpParseRef.current()
+    pumpAnalyzeRef.current()
+
     return () => {
-      workerRef.current?.terminate()
+      parseWorker.terminate()
+      analyzeWorker.terminate()
     }
   }, [])
 
   const parseFiles = useCallback((files: FileList | File[], allowFreerolls = false) => {
-    if (!workerRef.current) return
-
-    setState(prev => ({
-      ...prev,
-      isLoading: true,
-      progress: {
-        stage: 'init',
-        current: 0,
-        total: 1,
-        messageKey: 'progress.starting',
-        percentage: 0,
-      },
-      errors: [],
-    }))
-
-    // Convert FileList to array for worker
-    const fileArray = Array.from(files)
-
-    workerRef.current.postMessage({
-      type: 'parse',
-      files: fileArray,
-      allowFreerolls,
-    } as WorkerMessage)
+    pendingFilesRef.current = [...pendingFilesRef.current, ...Array.from(files)]
+    pendingAllowFreerollsRef.current = allowFreerolls
+    pumpParseRef.current()
   }, [])
 
   // Only run bankroll simulation for tournaments.
   // Hand history equity is handled independently by HandHistoryCharts.
   const runAnalysis = useCallback(() => {
-    if (!workerRef.current) return
-    if (state.tournaments.length === 0) return
-
-    setState(prev => ({
-      ...prev,
-      isLoading: true,
-      progress: {
-        stage: 'init',
-        current: 0,
-        total: 1,
-        messageKey: 'progress.startingAnalysis',
-        percentage: 0,
-      },
-    }))
-
-    workerRef.current.postMessage({
-      type: 'analyze',
-      tournaments: state.tournaments,
-    } as WorkerMessage)
-  }, [state.tournaments])
+    reanalyzePendingRef.current = true
+    pumpAnalyzeRef.current()
+  }, [])
 
   const reset = useCallback(() => {
+    parseBusyRef.current = false
+    analyzeBusyRef.current = false
+    pendingFilesRef.current = []
+    reanalyzePendingRef.current = false
     setState(initialState)
   }, [])
 
   return {
     ...state,
+    isLoading: state.isParsing || state.isAnalyzing,
     parseFiles,
     runAnalysis,
     reset,

--- a/web/src/hooks/useAnalysisWorker.ts
+++ b/web/src/hooks/useAnalysisWorker.ts
@@ -275,6 +275,13 @@ export function useAnalysisWorker(): UseAnalysisWorkerReturn {
     return () => {
       parseWorker.terminate()
       analyzeWorker.terminate()
+      // Reset coordination refs so a real mid-work remount can't leave a pump wedged against a
+      // terminated worker. (StrictMode's init-time remount has nothing in flight, so this is
+      // insurance rather than a fix for a live bug.)
+      parseBusyRef.current = false
+      analyzeBusyRef.current = false
+      pendingFilesRef.current = []
+      reanalyzePendingRef.current = false
     }
   }, [])
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -18,6 +18,8 @@
 
   "tabs.tournament": "Tournament Summary",
   "tabs.handHistory": "Hand History",
+  "tabs.tournamentDisabledTooltip": "Needs tournament results",
+  "tabs.handHistoryDisabledTooltip": "Needs hand history data",
 
   "errors.title": "Errors:",
   "errors.worker": "Worker error: {{message}}",
@@ -212,6 +214,7 @@
   "charts.noSituationData": "No hand history data loaded",
 
   "tabs.deepDive": "Deep Dive",
+  "tabs.deepDiveDisabledTooltip": "Needs both tournament results and hand histories",
   "errorBoundary.label.deepDiveCharts": "deep dive charts",
   "export.section.deepDive": "Deep Dive",
   "charts.noDeepDiveData": "No final-table runs found yet. Load matching tournament results and hand histories.",

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -18,6 +18,8 @@
 
   "tabs.tournament": "토너먼트 결과 분석",
   "tabs.handHistory": "핸드 히스토리 분석",
+  "tabs.tournamentDisabledTooltip": "토너먼트 결과 데이터가 필요합니다",
+  "tabs.handHistoryDisabledTooltip": "핸드 히스토리 데이터가 필요합니다",
 
   "errors.title": "오류:",
   "errors.worker": "워커 오류: {{message}}",
@@ -212,6 +214,7 @@
   "charts.noSituationData": "불러온 핸드 히스토리 데이터가 없습니다",
 
   "tabs.deepDive": "심층 분석",
+  "tabs.deepDiveDisabledTooltip": "토너먼트 결과와 핸드 히스토리 데이터가 모두 필요합니다",
   "errorBoundary.label.deepDiveCharts": "심층 분석 차트",
   "export.section.deepDive": "심층 분석",
   "charts.noDeepDiveData": "파이널 테이블 기록이 없습니다. 서로 맞는 토너먼트 결과와 핸드 히스토리를 불러오세요.",


### PR DESCRIPTION
Two follow-ups to the Deep Dive PR.

## Item 1 — disabled-tab tooltips (all tabs)

Every disabled tab now shows a hover tooltip explaining which data it needs — Tournament → "Needs tournament results", Hand History / Preflop Situations → "Needs hand history data", Deep Dive → "Needs both tournament results and hand histories". `ChartTabs` is refactored to be config-driven so the four tabs share one implementation.

It's a CSS `::after` tooltip (not a native `title`, which doesn't reliably fire on a disabled `<button>`), positioned **above** the tab with a down-arrow so it no longer covers the first chart section.

## Item 2 — upload during the bankroll simulation

**Parsing and the bankroll simulation now run on separate workers** (each with its own WASM instance). Previously they shared one worker, so a hand-history upload during the sim was queued behind it and its charts/all-in-equity couldn't start until the sim finished. Now the parse runs concurrently and the hand-history analysis starts right away — matching how the all-in equity worker already behaves.

The bankroll-sim **progress moved below the tabs**, into the tournament tab's loading slot, showing the real "Simulating N buy-ins…" message — consistent with the equity progress in the hand-history tab. The generic above-tabs "Analyzing…" indicator is removed.

Memory cost of the second worker: ~5–20 MB (a lightly-used WASM instance; it does **not** load the 686 KB preflop cache, which parsing never touches).

## Verification

- 247 unit/render tests pass, incl. new tests for the all-tabs tooltips and the below-tabs sim message; `tsc -b` and `npm run build` are clean.
- Interactive behavior (concurrent parse during the sim; tooltip positioning) confirmed via `npm run dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZpcMRojRfvf4AvmHqXmcx
