### PR TITLE
Render heavy charts with WebGL (scattergl): RR-by-Rank + Chip Histories

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -120,6 +120,17 @@ function App() {
     }
   }, [tournaments, runAnalysis])
 
+  // Plotly sizes each chart to its container at draw time. A chart first drawn inside a hidden
+  // (`display:none`) tab is drawn at width 0: an SVG chart still recovers, because the browser
+  // scales its viewBox to the container once shown, but a WebGL (`scattergl`) chart's drawing
+  // buffer stays 0×0 and paints blank until something resizes it. react-plotly's `useResizeHandler`
+  // listens on window resize only, so nudge it on every tab switch — by the time this effect runs
+  // the now-visible tab has its real width, and the dispatch makes every mounted Plot re-fit. This
+  // became load-bearing when the RR-by-Rank and Chip Histories charts moved to WebGL.
+  useEffect(() => {
+    window.dispatchEvent(new Event('resize'))
+  }, [activeTab])
+
   // The export follows whatever language the site is currently in: the charts were
   // built in it, so anything else would mean rebuilding every figure.
   const language = i18n.resolvedLanguage ?? 'en'

--- a/web/src/visualization/handHistory/chipHistories.ts
+++ b/web/src/visualization/handHistory/chipHistories.ts
@@ -98,8 +98,9 @@ export async function getChipHistoriesData(
     // One gl line per tournament. This is the heavy trace — ~943 lines / ~76k vertices on the
     // real data — and it is the only thing here worth moving to WebGL. The danger line, survival
     // curve, and death-threshold bar below stay SVG on purpose: they are one trace each (no perf
-    // reason), the survival curve needs `fill` (gl's weak spot), and being SVG they paint above
-    // this WebGL layer so the danger line and overlays stay on top of the chip trajectories.
+    // reason) and the survival curve needs `fill` (gl's weak spot). The danger line also shares
+    // this subplot with the chip lines, and being SVG it paints above the WebGL layer, so it stays
+    // on top of the trajectories (the survival curve and bar sit on their own grid panels).
     traces.push({
       type: 'scattergl',
       x: xValues,

--- a/web/src/visualization/handHistory/chipHistories.ts
+++ b/web/src/visualization/handHistory/chipHistories.ts
@@ -95,8 +95,13 @@ export async function getChipHistoriesData(
     const normalizedHistory = displayHistory.map(chips => chips / initialChips)
     const xValues = normalizedHistory.map((_, i) => i + 1)
 
+    // One gl line per tournament. This is the heavy trace — ~943 lines / ~76k vertices on the
+    // real data — and it is the only thing here worth moving to WebGL. The danger line, survival
+    // curve, and death-threshold bar below stay SVG on purpose: they are one trace each (no perf
+    // reason), the survival curve needs `fill` (gl's weak spot), and being SVG they paint above
+    // this WebGL layer so the danger line and overlays stay on top of the chip trajectories.
     traces.push({
-      type: 'scatter',
+      type: 'scattergl',
       x: xValues,
       y: normalizedHistory,
       mode: 'lines',

--- a/web/src/visualization/handHistory/handHistory.test.ts
+++ b/web/src/visualization/handHistory/handHistory.test.ts
@@ -72,6 +72,31 @@ describe('chipHistories', () => {
     expect(result.traces.length).toBeGreaterThan(0)
     expect(result.layout.title).toEqual({ text: 'chart.chipHistories.title' })
   })
+
+  // The per-tournament chip lines are a WebGL trace (`scattergl`) — ~943 lines / ~76k points on
+  // real data, the only heavy trace here. The danger line, survival curve, and death-threshold bar
+  // stay non-gl: one trace each, the survival curve needs `fill` (gl's weak spot), and as SVG they
+  // paint above the WebGL layer so the danger line and overlays stay on top. The overlays all share
+  // `mode:'lines'` with the chip lines, so they're identified by name, not mode.
+  it('uses WebGL only for the per-tournament chip lines, SVG for the overlays', async () => {
+    const hh1 = createMockHandHistory({ id: 'TM00001', tournamentId: 1, wons: new Map([['Hero', 50]]) })
+    const hh2 = createMockHandHistory({ id: 'TM00002', tournamentId: 2, wons: new Map([['Hero', 100]]) })
+
+    const { traces } = await getChipHistoriesData([hh1, hh2], identityT)
+    const typeOf = (name: string) =>
+      (traces.find(tr => (tr as { name?: string }).name === name) as { type?: string } | undefined)
+        ?.type
+
+    // Every gl trace is a per-tournament chip line (mode 'lines'), and there is at least one.
+    const gl = traces.filter(tr => (tr as { type?: string }).type === 'scattergl')
+    expect(gl.length).toBeGreaterThan(0)
+    for (const tr of gl) expect((tr as { mode?: string }).mode).toBe('lines')
+
+    // The overlays stay off the WebGL layer.
+    expect(typeOf('chart.chipHistories.legend.dangerLine')).toBe('scatter')
+    expect(typeOf('chart.chipHistories.legend.survivalRate')).toBe('scatter')
+    expect(typeOf('chart.chipHistories.legend.deathThreshold')).toBe('bar')
+  })
 })
 
 describe('handUsageHeatmaps', () => {

--- a/web/src/visualization/handHistory/handHistory.test.ts
+++ b/web/src/visualization/handHistory/handHistory.test.ts
@@ -75,9 +75,9 @@ describe('chipHistories', () => {
 
   // The per-tournament chip lines are a WebGL trace (`scattergl`) — ~943 lines / ~76k points on
   // real data, the only heavy trace here. The danger line, survival curve, and death-threshold bar
-  // stay non-gl: one trace each, the survival curve needs `fill` (gl's weak spot), and as SVG they
-  // paint above the WebGL layer so the danger line and overlays stay on top. The overlays all share
-  // `mode:'lines'` with the chip lines, so they're identified by name, not mode.
+  // stay non-gl: one trace each, and the survival curve needs `fill` (gl's weak spot). The danger
+  // line and survival curve also share `mode:'lines'` with the chip lines, so they're identified by
+  // name, not mode.
   it('uses WebGL only for the per-tournament chip lines, SVG for the overlays', async () => {
     const hh1 = createMockHandHistory({ id: 'TM00001', tournamentId: 1, wons: new Map([['Hero', 50]]) })
     const hh2 = createMockHandHistory({ id: 'TM00002', tournamentId: 2, wons: new Map([['Hero', 100]]) })

--- a/web/src/visualization/tournament/rrByRank.ts
+++ b/web/src/visualization/tournament/rrByRank.ts
@@ -101,9 +101,14 @@ export function getRRByRankData(tournaments: TournamentSummary[], t: Translate):
   }
 
   const traces: Data[] = [
-    // Main scatter: RR by percentile
+    // Main scatter: RR by percentile.
+    // WebGL (`scattergl`), not SVG `scatter`: this is one marker per cashed tournament — up to a
+    // few thousand across a full 12-month history — and SVG markers turn hover/zoom janky at that
+    // count. Markers are exactly what WebGL renders best. The regression line below deliberately
+    // stays SVG (see there). Exports keep working: the standalone HTML re-renders trace JSON against
+    // the full Plotly CDN build, which ships the gl renderer.
     {
-      type: 'scatter',
+      type: 'scattergl',
       x: rankPercentiles,
       y: rrValues,
       mode: 'markers',
@@ -111,9 +116,9 @@ export function getRRByRankData(tournaments: TournamentSummary[], t: Translate):
       customdata: data.map(d => [d.name, d.totalPlayers, d.rank, d.rr, d.peRR]),
       hovertemplate: t('chart.rrByRank.hover.rr'),
     } as Data,
-    // Secondary scatter: PERR (on secondary y-axis)
+    // Secondary scatter: PERR (on secondary y-axis) — same per-tournament markers, same reason for gl.
     {
-      type: 'scatter',
+      type: 'scattergl',
       x: rankPercentiles,
       y: peRRValues,
       mode: 'markers',
@@ -124,7 +129,8 @@ export function getRRByRankData(tournaments: TournamentSummary[], t: Translate):
       hovertemplate: t('chart.rrByRank.hover.perr'),
       yaxis: 'y2',
     } as Data,
-    // Regression line
+    // Regression line — stays SVG `scatter`. It is a handful of fitted points, so gl buys nothing,
+    // and as an SVG trace it paints *above* the WebGL layer, keeping the trend line on top of the dots.
     {
       type: 'scatter',
       x: fittedX,

--- a/web/src/visualization/tournament/tournament.test.ts
+++ b/web/src/visualization/tournament/tournament.test.ts
@@ -48,6 +48,19 @@ describe('getRRByRankData', () => {
     expect(layout.title).toEqual({ text: 'chart.rrByRank.title' })
   })
 
+  // The per-tournament dots are a WebGL trace (`scattergl`) so a full history of a few thousand
+  // markers stays smooth on hover/zoom; the fitted line stays SVG `scatter` so it paints on top.
+  it('renders the per-tournament markers with WebGL and keeps the trend line as SVG', () => {
+    const { traces } = getRRByRankData([cashed(1), cashed(2), busted(3)], identityT)
+
+    const markerTraces = traces.filter(tr => (tr as { mode?: string }).mode === 'markers')
+    const lineTraces = traces.filter(tr => (tr as { mode?: string }).mode === 'lines')
+    expect(markerTraces.length).toBeGreaterThan(0)
+    expect(lineTraces.length).toBeGreaterThan(0)
+    for (const tr of markerTraces) expect((tr as { type?: string }).type).toBe('scattergl')
+    for (const tr of lineTraces) expect((tr as { type?: string }).type).toBe('scatter')
+  })
+
   // Regression: with nothing to plot, `minPercentile` stayed at its Infinity sentinel and
   // the x-axis range came out as [0, Infinity] — a blank plot with a nonsense axis rather
   // than the "no data" state every other builder shows, and [0, null] in the export.


### PR DESCRIPTION
## What

Move the two heaviest scatter charts from SVG to Plotly's WebGL renderer (`scattergl`), where the point/line count makes SVG janky on hover and zoom.

### RR-by-Rank
One marker per cashed tournament — up to a few thousand across a full 12-month history (3,769 summaries in the real damavaco data before the cash filter). Switches the two per-tournament marker traces (main RR + the legend-only PERR trace) to `scattergl`. The regression line stays SVG `scatter`: a handful of fitted points (no perf gain from gl), and as SVG it paints *above* the WebGL layer, keeping the trend line on top of the dots.

### Chip Histories
The main panel draws one line per tournament — ~943 lines / ~76,100 vertices on real data, all re-projected through a log-y axis every pan/zoom frame. Switches just the per-tournament trajectory lines to `scattergl`. The three one-off overlays stay non-gl on purpose: the dashed danger line and the death-threshold bar are one trace each (no perf reason), the survival curve needs `fill` (gl's weak spot), and being SVG they paint above the WebGL layer so the danger line and overlays stay on top.

## Why it's safe

- **Export unaffected.** The standalone HTML export re-embeds trace JSON and re-renders against the full Plotly CDN build (`plotly-3.3.1.min.js`), which ships the gl renderer. Verified the exported Chip Histories section renders.
- **WebGL context budget.** These two charts live in separate graph divs → 2 contexts, well within the browser ceiling, even with all tabs kept mounted (`display:none`).
- **Fidelity verified in the browser on real data** (Chip Histories): appreciably smoother hover/zoom once loaded (slightly longer initial load, acceptable); log-y axis, dashed danger line, other panels, annotations, and HTML export all correct.

## Tests

- New intent-pinning tests: RR-by-Rank markers are `scattergl` / trend line stays `scatter`; Chip Histories per-tournament lines are `scattergl` while the danger line / survival curve / death-threshold overlays stay non-gl (identified by name, since they share `mode:'lines'`).
- Full web suite green (249 tests); `npm run build` typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZpcMRojRfvf4AvmHqXmcx